### PR TITLE
feat: add explore page and link card

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "react-router-dom": "^7.7.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.30.1",
@@ -1849,6 +1850,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -3297,6 +3307,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.7.0.tgz",
+      "integrity": "sha512-3FUYSwlvB/5wRJVTL/aavqHmfUKe0+Xm9MllkYgGo9eDwNdkvwlJGjpPxono1kCycLt6AnDTgjmXvK3/B4QGuw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.7.0.tgz",
+      "integrity": "sha512-wwGS19VkNBkneVh9/YD0pK3IsjWxQUVMDD6drlG7eJpo1rXBtctBqDyBm/k+oKHRAm1x9XWT3JFC82QI9YOXXA==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.7.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -3444,6 +3492,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -11,20 +11,21 @@
   },
   "dependencies": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^7.7.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.6.0",
+    "autoprefixer": "^10.x.x",
     "eslint": "^9.30.1",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^16.3.0",
-    "tailwindcss": "^3.x.x",
     "postcss": "^8.x.x",
-    "autoprefixer": "^10.x.x",
+    "tailwindcss": "^3.x.x",
     "vite": "^7.0.4"
   }
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,16 @@
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom'
 import Home from './pages/Home.jsx'
+import Explore from './pages/Explore.jsx'
 
 function App() {
-  return <Home />
+  return (
+    <Router>
+      <Routes>
+        <Route path="/" element={<Home />} />
+        <Route path="/explore" element={<Explore />} />
+      </Routes>
+    </Router>
+  )
 }
 
 export default App

--- a/src/components/LinkCard.jsx
+++ b/src/components/LinkCard.jsx
@@ -1,0 +1,30 @@
+import React from 'react'
+
+function LinkCard({ title, description, tags = [], url }) {
+  return (
+    <div className="bg-white p-4 rounded shadow space-y-2">
+      <h2 className="text-xl font-semibold">{title}</h2>
+      <p className="text-gray-700">{description}</p>
+      <div className="flex flex-wrap gap-2">
+        {tags.map((tag) => (
+          <span
+            key={tag}
+            className="px-2 py-1 bg-blue-100 text-blue-800 rounded text-sm"
+          >
+            #{tag}
+          </span>
+        ))}
+      </div>
+      <a
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="inline-block mt-2 px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600"
+      >
+        前往連結
+      </a>
+    </div>
+  )
+}
+
+export default LinkCard

--- a/src/pages/Explore.jsx
+++ b/src/pages/Explore.jsx
@@ -1,0 +1,33 @@
+import React from 'react'
+import Header from '../components/Header.jsx'
+import LinkCard from '../components/LinkCard.jsx'
+
+function Explore() {
+  const links = [
+    {
+      title: '示範連結 1',
+      description: '範例對話描述',
+      tags: ['ChatGPT', '示範'],
+      url: 'https://chat.openai.com/share/example-1',
+    },
+    {
+      title: '示範連結 2',
+      description: '另外一個對話範例',
+      tags: ['AI', '分享'],
+      url: 'https://chat.openai.com/share/example-2',
+    },
+  ]
+
+  return (
+    <div className="min-h-screen bg-gray-50 p-6 space-y-6">
+      <Header />
+      <div className="max-w-screen-md mx-auto space-y-4">
+        {links.map((link) => (
+          <LinkCard key={link.url} {...link} />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export default Explore

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { Link } from 'react-router-dom'
 import Header from '../components/Header.jsx'
 
 function Home() {
@@ -7,7 +8,12 @@ function Home() {
       <div className="max-w-screen-sm w-full space-y-6 text-center">
         <Header />
         <p className="text-gray-700">蒐集與分類各種 ChatGPT 對話連結的平台</p>
-        <button className="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600">馬上開始探索</button>
+        <Link
+          to="/explore"
+          className="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600"
+        >
+          馬上開始探索
+        </Link>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- add react-router-dom dependency
- introduce LinkCard component
- create Explore page with sample links
- wire up routing in App and update Home button

## Testing
- `npm run lint`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_687ca88c3ea08327af39b5bcb33708e2