### PR TITLE
Add ValidatorAgent and MetaAgent

### DIFF
--- a/src/agents/MetaAgent.js
+++ b/src/agents/MetaAgent.js
@@ -1,0 +1,16 @@
+/**
+ * Extracts basic metadata from a conversation link
+ */
+
+export default class MetaAgent {
+  constructor(options = {}) {
+    this.options = options
+  }
+
+  run(link) {
+    const platform = link.includes('chat.openai.com') ? 'ChatGPT' : 'Unknown'
+    const title = 'Untitled Chat'
+    const language = 'unknown'
+    return { title, platform, language }
+  }
+}

--- a/src/agents/ValidatorAgent.js
+++ b/src/agents/ValidatorAgent.js
@@ -1,0 +1,14 @@
+/**
+ * Validates that a link is a public ChatGPT share URL
+ */
+
+export default class ValidatorAgent {
+  constructor(options = {}) {
+    this.options = options
+  }
+
+  run(link) {
+    const pattern = /^https?:\/\/chat\.openai\.com\/share\/[a-zA-Z0-9-]+$/
+    return { link, valid: pattern.test(link) }
+  }
+}


### PR DESCRIPTION
## Summary
- implement `ValidatorAgent` for verifying ChatGPT share URLs
- implement `MetaAgent` returning placeholder metadata

## Testing
- `npm run lint`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_687cb41d80d08327a9aa72729e5810a4