### PR TITLE
Add validate meta API

### DIFF
--- a/api/validate-meta.ts
+++ b/api/validate-meta.ts
@@ -1,0 +1,16 @@
+import type { Request, Response } from 'express'
+import ValidatorAgent from '../src/agents/ValidatorAgent.js'
+import MetaAgent from '../src/agents/MetaAgent.js'
+
+const validator = new ValidatorAgent()
+const meta = new MetaAgent()
+
+export default function validateMeta(req: Request, res: Response) {
+  const { link } = req.body || {}
+  const validation = validator.run(link)
+  if (!validation.valid) {
+    return res.status(400).json(validation)
+  }
+  const metadata = meta.run(link)
+  return res.json({ ...validation, ...metadata })
+}


### PR DESCRIPTION
## Summary
- add an Express handler at `api/validate-meta.ts`
- handler validates the link then fetches metadata

## Testing
- `npm run lint`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_687cb6eeda0c8327af1b2e03f6ccc613