### PR TITLE
Enhance link handling and metadata fetch

### DIFF
--- a/api/validate-meta.js
+++ b/api/validate-meta.js
@@ -4,12 +4,12 @@ import MetaAgent from '../src/agents/MetaAgent.js'
 const validator = new ValidatorAgent()
 const meta = new MetaAgent()
 
-export default function validateMeta(req, res) {
+export default async function validateMeta(req, res) {
   const { link } = req.body || {}
   const validation = validator.run(link)
   if (!validation.valid) {
     return res.status(400).json(validation)
   }
-  const metadata = meta.run(link)
+  const metadata = await meta.run(link)
   return res.json({ ...validation, ...metadata })
 }

--- a/src/agents/MetaAgent.js
+++ b/src/agents/MetaAgent.js
@@ -7,9 +7,22 @@ export default class MetaAgent {
     this.options = options
   }
 
-  run(link) {
+  async run(link) {
     const platform = link.includes('chat.openai.com') ? 'ChatGPT' : 'Unknown'
-    const title = 'Untitled Chat'
+    let title = 'Untitled Chat'
+    try {
+      const res = await fetch(link)
+      const html = await res.text()
+      const og = html.match(/<meta[^>]*property=["']og:title["'][^>]*content=["']([^"']+)["'][^>]*>/i)
+      if (og) {
+        title = og[1]
+      } else {
+        const t = html.match(/<title>([^<]*)<\/title>/i)
+        if (t) title = t[1]
+      }
+    } catch {
+      /* ignore fetch errors */
+    }
     const language = 'unknown'
     return { title, platform, language }
   }

--- a/src/components/UploadLinkBox.jsx
+++ b/src/components/UploadLinkBox.jsx
@@ -8,13 +8,15 @@ function UploadLinkBox({ onAdd }) {
     if (!link) return
 
     try {
+      console.log('Submitting link', link)
       const res = await fetch('/api/validate-meta', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ url: link }),
+        body: JSON.stringify({ link }),
       })
       if (!res.ok) throw new Error('Request failed')
       const data = await res.json()
+      console.log('Response', data)
       if (onAdd) onAdd(data)
       setLink('')
     } catch (err) {

--- a/src/pages/Explore.jsx
+++ b/src/pages/Explore.jsx
@@ -20,7 +20,13 @@ function Explore() {
   ])
 
   function handleAdd(data) {
-    setLinks((prev) => [...prev, data])
+    const linkObj = {
+      url: data.link,
+      title: data.title,
+      description: '',
+      tags: [],
+    }
+    setLinks((prev) => [...prev, linkObj])
   }
 
   return (


### PR DESCRIPTION
## Summary
- log network activity and send `{ link }` body when submitting a link
- map API response to new link object in Explore page
- fetch Open Graph title in `MetaAgent`
- make metadata lookup async in API

## Testing
- `npm run lint`
- `npm run dev` *(startup only)*

------
https://chatgpt.com/codex/tasks/task_e_687cc9dd83fc8327b564460ec32582ad