### PR TITLE
Add API proxy to Vite dev server

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -4,4 +4,12 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:3000',
+        changeOrigin: true,
+      },
+    },
+  },
 })


### PR DESCRIPTION
## Summary
- forward `/api` requests to the backend when running `vite`

## Testing
- `npm run lint`
- `npm run dev` *(terminated after startup)*

------
https://chatgpt.com/codex/tasks/task_e_687cd140423c832782560071bb860739