### PR TITLE
feat: normalize link items

### DIFF
--- a/src/components/LinkCard.jsx
+++ b/src/components/LinkCard.jsx
@@ -1,12 +1,17 @@
 import React from 'react'
 
 function LinkCard({ title, description, tags = [], url }) {
+  const displayTitle = title || '未命名'
+  const displayTags = tags?.length > 0 ? tags : ['未分類']
+
+  console.log('渲染的項目：', { title, description, tags, url })
+
   return (
     <div className="bg-white p-4 rounded shadow space-y-2">
-      <h2 className="text-xl font-semibold">{title}</h2>
+      <h2 className="text-xl font-semibold">{displayTitle}</h2>
       <p className="text-gray-700">{description}</p>
       <div className="flex flex-wrap gap-2">
-        {tags.map((tag) => (
+        {displayTags.map((tag) => (
           <span
             key={tag}
             className="px-2 py-1 bg-blue-100 text-blue-800 rounded text-sm"

--- a/src/pages/Explore.jsx
+++ b/src/pages/Explore.jsx
@@ -3,6 +3,17 @@ import Header from '../components/Header.jsx'
 import UploadLinkBox from '../components/UploadLinkBox.jsx'
 import LinkCard from '../components/LinkCard.jsx'
 
+function normalizeItem(data) {
+  return {
+    url: data.url || data.link,
+    title: data.title || '未命名',
+    tags: Array.isArray(data.tags) ? data.tags : [],
+    platform: data.platform || 'Unknown',
+    language: data.language || 'unknown',
+    description: data.description || '',
+  }
+}
+
 function Explore() {
   const [links, setLinks] = useState([
     {
@@ -20,13 +31,12 @@ function Explore() {
   ])
 
   function handleAdd(data) {
-    const linkObj = {
-      url: data.link,
-      title: data.title,
-      description: '',
-      tags: [],
-    }
-    setLinks((prev) => [...prev, linkObj])
+    setLinks((prev) => [...prev, normalizeItem(data)])
+  }
+
+  function renderListItem(link) {
+    console.log('渲染的項目：', link)
+    return <LinkCard key={link.url} {...link} />
   }
 
   return (
@@ -36,7 +46,7 @@ function Explore() {
         <UploadLinkBox onAdd={handleAdd} />
         <div className="w-full space-y-4">
           {links.length > 0 ? (
-            links.map((link) => <LinkCard key={link.url} {...link} />)
+            links.map((link) => renderListItem(link))
           ) : (
             <p className="text-center text-gray-500">Loading...</p>
           )}


### PR DESCRIPTION
## Summary
- add a `normalizeItem` helper to ensure default values
- show fallback title and tags in `LinkCard`
- log items when rendering to debug
- render list items through a helper for clarity

## Testing
- `npm run lint`
- `npm run dev` *(terminated after startup)*

------
https://chatgpt.com/codex/tasks/task_e_687e0ee37e7883279b8d5bfcd0f8bccf