### PR TITLE
Update explore layout

### DIFF
--- a/src/components/LinkCard.jsx
+++ b/src/components/LinkCard.jsx
@@ -1,12 +1,15 @@
 import React from 'react'
 
-function LinkCard({ title, description, tags = [], url }) {
+function LinkCard({ title, description, tags = [], url, onSelect }) {
   const displayTitle = title || '未命名'
   const displayTags = tags?.length > 0 ? tags : ['未分類']
 
 
   return (
-    <div className="bg-white p-4 rounded shadow space-y-2">
+    <div
+      className="bg-white p-4 rounded-lg shadow space-y-2 cursor-pointer"
+      onClick={onSelect}
+    >
       <h2 className="text-xl font-semibold">{displayTitle}</h2>
       <p className="text-gray-700">{description}</p>
       <div className="flex flex-wrap gap-2">

--- a/src/components/UploadLinkBox.jsx
+++ b/src/components/UploadLinkBox.jsx
@@ -28,19 +28,19 @@ export default function UploadLinkBox({ onAdd }) {
   return (
     <div className="bg-white p-4 rounded shadow space-y-3 w-full max-w-md">
       <input
-        className="w-full border rounded px-3 py-2"
+        className="w-full border rounded px-3 py-2 text-black focus:outline-none focus:ring-2 focus:ring-blue-500"
         placeholder="貼上公開分享連結"
         value={link}
         onChange={(e) => setLink(e.target.value)}
       />
       <input
-        className="w-full border rounded px-3 py-2"
+        className="w-full border rounded px-3 py-2 text-black focus:outline-none focus:ring-2 focus:ring-blue-500"
         placeholder="自訂標題（可留空）"
         value={title}
         onChange={(e) => setTitle(e.target.value)}
       />
       <input
-        className="w-full border rounded px-3 py-2"
+        className="w-full border rounded px-3 py-2 text-black focus:outline-none focus:ring-2 focus:ring-blue-500"
         placeholder="標籤（以逗號分隔，例如 ChatGPT, 分類A）"
         value={tags}
         onChange={(e) => setTags(e.target.value)}

--- a/src/pages/Explore.jsx
+++ b/src/pages/Explore.jsx
@@ -29,26 +29,46 @@ function Explore() {
       url: 'https://chat.openai.com/share/example-2',
     },
   ])
+  const [selectedLink, setSelectedLink] = useState(null)
 
   function handleAdd(data) {
     setLinks((prev) => [...prev, normalizeItem(data)])
   }
 
   function renderListItem(link) {
-    return <LinkCard key={link.url} {...link} />
+    return (
+      <LinkCard
+        key={link.url}
+        {...link}
+        onSelect={() => setSelectedLink(link)}
+      />
+    )
   }
 
   return (
-    <div className="min-h-screen bg-gray-50 px-4 flex justify-center items-start">
-      <div className="w-full max-w-screen-md space-y-6">
+    <div className="min-h-screen bg-gray-50 flex justify-center items-start px-6 py-8">
+      <div className="w-full max-w-screen-lg space-y-6">
         <Header />
-        <UploadLinkBox onAdd={handleAdd} />
-        <div className="space-y-4">
-          {links.length > 0 ? (
-            links.map((link) => renderListItem(link))
-          ) : (
-            <p className="text-center text-gray-500">Loading...</p>
-          )}
+        <div className="flex gap-6">
+          <div className="w-1/2 space-y-6">
+            <UploadLinkBox onAdd={handleAdd} />
+            <div className="space-y-6">
+              {links.length > 0 ? (
+                links.map((link) => renderListItem(link))
+              ) : (
+                <p className="text-center text-gray-500">Loading...</p>
+              )}
+            </div>
+          </div>
+          <div className="w-1/2">
+            {selectedLink ? (
+              <LinkCard {...selectedLink} />
+            ) : (
+              <div className="bg-gray-100 text-gray-500 flex items-center justify-center h-full p-6 rounded">
+                請選擇一個連結以預覽
+              </div>
+            )}
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- improve spacing and fix text color for UploadLinkBox inputs
- allow selecting a LinkCard and preview it
- split Explore view into two columns with a preview pane

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68804c19ffd8832791af11f0fd989dbe