### PR TITLE
Add preview card component

### DIFF
--- a/src/components/PreviewCard.jsx
+++ b/src/components/PreviewCard.jsx
@@ -1,0 +1,42 @@
+import React, { useEffect, useState } from 'react'
+
+function PreviewCard({ title, description, tags = [], url }) {
+  const [visible, setVisible] = useState(false)
+
+  useEffect(() => {
+    const id = setTimeout(() => setVisible(true), 0)
+    return () => clearTimeout(id)
+  }, [])
+
+  const displayTitle = title || '未命名'
+  const displayTags = Array.isArray(tags) && tags.length > 0 ? tags : ['未分類']
+
+  return (
+    <div
+      className={`bg-white p-4 rounded-lg shadow space-y-2 transition-opacity duration-500 ${visible ? 'opacity-100' : 'opacity-0'}`}
+    >
+      <h2 className="text-xl font-semibold">{displayTitle}</h2>
+      <p className="text-gray-700">{description}</p>
+      <div className="flex flex-wrap gap-2">
+        {displayTags.map((tag) => (
+          <span
+            key={tag}
+            className="px-2 py-1 bg-blue-100 text-blue-800 rounded text-sm"
+          >
+            #{tag}
+          </span>
+        ))}
+      </div>
+      <a
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="inline-block mt-2 px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600"
+      >
+        前往連結
+      </a>
+    </div>
+  )
+}
+
+export default PreviewCard

--- a/src/pages/Explore.jsx
+++ b/src/pages/Explore.jsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react'
 import Header from '../components/Header.jsx'
 import UploadLinkBox from '../components/UploadLinkBox.jsx'
 import LinkCard from '../components/LinkCard.jsx'
+import PreviewCard from '../components/PreviewCard.jsx'
 
 function normalizeItem(data) {
   return {
@@ -62,7 +63,7 @@ function Explore() {
           </div>
           <div className="w-1/2">
             {selectedLink ? (
-              <LinkCard {...selectedLink} />
+              <PreviewCard key={selectedLink.url} {...selectedLink} />
             ) : (
               <div className="bg-gray-100 text-gray-500 flex items-center justify-center h-full p-6 rounded">
                 請選擇一個連結以預覽


### PR DESCRIPTION
## Summary
- show a preview card when a link is selected
- animate preview card fade in

## Testing
- `npm run lint`
- `npm run dev` *(terminated after startup)*

------
https://chatgpt.com/codex/tasks/task_e_688057a3bb58832786c3f8afe21540d9