### PR TITLE
Fix placeholder in Explore page

### DIFF
--- a/src/pages/Explore.jsx
+++ b/src/pages/Explore.jsx
@@ -57,7 +57,7 @@ function Explore() {
               {links.length > 0 ? (
                 links.map((link) => renderListItem(link))
               ) : (
-                <p className="text-center text-gray-500">Loading...</p>
+                <p className="text-center text-gray-500">目前沒有連結</p>
               )}
             </div>
           </div>


### PR DESCRIPTION
## Summary
- replace the outdated `Loading...` label in Explore with **目前沒有連結**

## Testing
- `npm run lint`
- `npm run dev` *(verified startup and then stopped)*

------
https://chatgpt.com/codex/tasks/task_e_688059a21c4483278bc7718cf140eda3