### PR TITLE
feat: wrap home link

### DIFF
--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -8,12 +8,14 @@ function Home() {
       <div className="max-w-screen-sm w-full space-y-6 text-center">
         <Header />
         <p className="text-gray-700">蒐集與分類各種 ChatGPT 對話連結的平台</p>
-        <Link
-          to="/explore"
-          className="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600"
-        >
-          馬上開始探索
-        </Link>
+        <div className="mt-4">
+          <Link
+            to="/explore"
+            className="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600"
+          >
+            馬上開始探索
+          </Link>
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- wrap the explore link on the home page with a margin div

## Testing
- `npm run lint` *(fails: handleKeyDown/baseClass unused)*

------
https://chatgpt.com/codex/tasks/task_e_6880942a245483279329ba60267913ae