### PR TITLE
fix: update input styling and layout

### DIFF
--- a/src/components/LinkCard.jsx
+++ b/src/components/LinkCard.jsx
@@ -4,15 +4,6 @@ function LinkCard({ title, description, tags = [], url, onSelect, onDelete }) {
   const displayTitle = title || '未命名'
   const displayTags = tags?.length > 0 ? tags : ['未分類']
 
-  function handleKeyDown(e) {
-    if (!onSelect) return
-    if (e.key === 'Enter' || e.key === ' ') {
-      e.preventDefault()
-      onSelect(e)
-    }
-  }
-
-  const baseClass = 'bg-white p-4 rounded-lg shadow space-y-2'
 
   return (
     <div
@@ -30,7 +21,7 @@ function LinkCard({ title, description, tags = [], url, onSelect, onDelete }) {
           🗑️
         </button>
       )}
-      <h2 className="text-xl font-semibold">{displayTitle}</h2>
+      <h2 className="text-xl font-semibold text-black">{displayTitle}</h2>
       <p className="text-gray-700">{description}</p>
       <div className="flex flex-wrap gap-2">
         {displayTags.map((tag) => (

--- a/src/components/PreviewCard.jsx
+++ b/src/components/PreviewCard.jsx
@@ -15,7 +15,7 @@ function PreviewCard({ title, description, tags = [], url }) {
     <div
       className={`bg-white p-4 rounded-lg shadow space-y-2 transition-opacity duration-500 ${visible ? 'opacity-100' : 'opacity-0'}`}
     >
-      <h2 className="text-xl font-semibold">{displayTitle}</h2>
+      <h2 className="text-xl font-semibold text-black">{displayTitle}</h2>
       <p className="text-gray-700">{description}</p>
       <div className="flex flex-wrap gap-2">
         {displayTags.map((tag) => (

--- a/src/components/UploadLinkBox.jsx
+++ b/src/components/UploadLinkBox.jsx
@@ -47,13 +47,13 @@ export default function UploadLinkBox({ onAdd }) {
         onChange={(e) => setLink(e.target.value)}
       />
       <input
-        className="w-full border rounded px-3 py-2 text-black focus:outline-none focus:ring-2 focus:ring-blue-500"
+        className="w-full bg-black text-white border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
         placeholder="自訂標題（可留空）"
         value={title}
         onChange={(e) => setTitle(e.target.value)}
       />
       <input
-        className="w-full border rounded px-3 py-2 text-black focus:outline-none focus:ring-2 focus:ring-blue-500"
+        className="w-full bg-black text-white border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
         placeholder="標籤（以逗號分隔，例如 ChatGPT, 分類A）"
         value={tags}
         onChange={(e) => setTags(e.target.value)}

--- a/src/pages/Explore.jsx
+++ b/src/pages/Explore.jsx
@@ -74,8 +74,8 @@ function Explore() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50 flex justify-center items-start px-6 py-8">
-      <div className="w-full max-w-screen-lg space-y-6">
+    <div className="min-h-screen bg-gray-50 flex justify-center items-start px-6 py-8 overflow-x-hidden">
+      <div className="container mx-auto px-4 space-y-6">
         <Header />
         <div className="flex flex-col md:flex-row gap-6">
           <div className="w-full md:w-1/2 space-y-6">

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -4,8 +4,8 @@ import Header from '../components/Header.jsx'
 
 function Home() {
   return (
-    <div className="min-h-screen bg-gray-50 flex items-center justify-center p-6">
-      <div className="max-w-screen-sm w-full space-y-6 text-center">
+    <div className="min-h-screen bg-gray-50 flex items-center justify-center p-6 overflow-x-hidden">
+      <div className="container mx-auto px-4 max-w-screen-sm w-full space-y-6 text-center">
         <Header />
         <p className="text-gray-700">蒐集與分類各種 ChatGPT 對話連結的平台</p>
         <Link


### PR DESCRIPTION
## Summary
- ensure title and tag inputs show text on dark background
- display added titles in black text
- restrict layout width and hide horizontal overflow

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688094dab61c8327a22d6a1e9492c1c4