### PR TITLE
Fix exploring data initialization

### DIFF
--- a/src/pages/Explore.jsx
+++ b/src/pages/Explore.jsx
@@ -46,7 +46,19 @@ function Explore() {
     const stored = localStorage.getItem('links')
     if (stored) {
       try {
-        setLinks(JSON.parse(stored))
+        const parsed = JSON.parse(stored)
+        let changed = false
+        const normalized = parsed.map((item) => {
+          if (!item.createdBy) {
+            changed = true
+            return { ...item, createdBy: uid }
+          }
+          return item
+        })
+        if (changed) {
+          localStorage.setItem('links', JSON.stringify(normalized))
+        }
+        setLinks(normalized)
       } catch (e) {
         console.error('Failed to parse links from localStorage', e)
       }


### PR DESCRIPTION
## Summary
- set `createdBy` for old stored links in `useEffect`

## Testing
- `npm run lint`
- `npm run dev` (start and stop)

------
https://chatgpt.com/codex/tasks/task_e_6881eca5672c832791d1829f4d36b69a