### PR TITLE
Remove unused PreviewCard import

### DIFF
--- a/src/pages/Explore.jsx
+++ b/src/pages/Explore.jsx
@@ -2,7 +2,6 @@ import React, { useState, useEffect } from 'react'
 import Header from '../components/Header.jsx'
 import UploadLinkBox from '../components/UploadLinkBox.jsx'
 import LinkCard from '../components/LinkCard.jsx'
-import PreviewCard from '../components/PreviewCard.jsx'
 
 const USER_ID_KEY = 'userUuid'
 


### PR DESCRIPTION
## Summary
- remove leftover PreviewCard import from Explore page

## Testing
- `npm run lint`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_6881ed5f57f08327a55b75fb065c99b0