### PR TITLE
Add summary overlay from SummarizerAgent

### DIFF
--- a/src/agents/SummarizerAgent.js
+++ b/src/agents/SummarizerAgent.js
@@ -1,0 +1,24 @@
+export default class SummarizerAgent {
+  constructor(options = {}) {
+    this.options = options
+  }
+
+  async run(link) {
+    try {
+      const res = await fetch(link)
+      const html = await res.text()
+      const og = html.match(/<meta[^>]*property=['"]og:description['"][^>]*content=['"]([^'"]+)['"][^>]*>/i)
+      const desc = html.match(/<meta[^>]*name=['"]description['"][^>]*content=['"]([^'"]+)['"][^>]*>/i)
+      let summary = ''
+      if (og) summary = og[1]
+      else if (desc) summary = desc[1]
+      if (!summary) {
+        const text = html.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim()
+        summary = text.slice(0, 160)
+      }
+      return { summary }
+    } catch {
+      return { summary: '' }
+    }
+  }
+}

--- a/src/components/LinkCard.jsx
+++ b/src/components/LinkCard.jsx
@@ -1,12 +1,12 @@
 import React from 'react'
 
-function LinkCard({ title, description, tags = [], url, onSelect, onDelete }) {
+function LinkCard({ title, description, summary, tags = [], url, onSelect, onDelete }) {
   const displayTitle = title || '未命名'
   const displayTags = tags?.length > 0 ? tags : ['未分類']
 
   return (
     <div
-      className="bg-white p-2 md:p-4 rounded-lg shadow relative space-y-2 cursor-pointer text-sm md:text-base"
+      className="bg-white p-2 md:p-4 rounded-lg shadow relative space-y-2 cursor-pointer text-sm md:text-base group"
       onClick={onSelect}
     >
       {onDelete && (
@@ -40,6 +40,11 @@ function LinkCard({ title, description, tags = [], url, onSelect, onDelete }) {
       >
         前往連結
       </a>
+      {summary && (
+        <div className="pointer-events-none absolute inset-0 hidden group-hover:flex items-center justify-center bg-black bg-opacity-60 text-white text-xs p-4 rounded-lg">
+          <p>{summary}</p>
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- implement `SummarizerAgent` for simple meta description fetching
- store summary when loading links or adding new ones
- show a hover overlay with the summary in `LinkCard`

## Testing
- `npm run lint`
- `npm run dev` *(terminated with Ctrl+C)*

------
https://chatgpt.com/codex/tasks/task_e_6881f4a99b548327932448ed81e02804