### PR TITLE
Add SummarizerAgent with API

### DIFF
--- a/api/server.js
+++ b/api/server.js
@@ -2,11 +2,13 @@
 /* global process */
 import express from 'express'
 import validateMeta from './validate-meta.js'
+import summarize from './summarizer.js'
 
 const app = express()
 app.use(express.json())
 
 app.post('/api/validate-meta', validateMeta)
+app.post('/api/agent/summarizer', summarize)
 
 const port = process.env.PORT || 3000
 app.listen(port, () => {

--- a/api/summarizer.js
+++ b/api/summarizer.js
@@ -1,0 +1,9 @@
+import SummarizerAgent from '../src/agents/SummarizerAgent.js'
+
+const summarizer = new SummarizerAgent()
+
+export default async function summarize(req, res) {
+  const { link, content } = req.body || {}
+  const result = await summarizer.run({ link, content })
+  return res.json(result)
+}

--- a/src/agents/SummarizerAgent.js
+++ b/src/agents/SummarizerAgent.js
@@ -1,0 +1,29 @@
+/**
+ * Generates a short summary from a link or text content
+ */
+export default class SummarizerAgent {
+  constructor(options = {}) {
+    this.options = options
+  }
+
+  async run({ link, content } = {}) {
+    let text = content || ''
+
+    if (link && !text) {
+      try {
+        const res = await fetch(link)
+        const html = await res.text()
+        text = html.replace(/<[^>]*>/g, ' ')
+      } catch {
+        // ignore fetch errors
+      }
+    }
+
+    text = (text || '').replace(/\s+/g, ' ').trim()
+    if (!text) return { summary: '' }
+
+    const sentences = text.match(/[^.!?]+[.!?]/g) || [text]
+    const summary = sentences.slice(0, 3).join(' ').trim()
+    return { summary }
+  }
+}


### PR DESCRIPTION
## Summary
- add SummarizerAgent for three-sentence summaries
- expose API route `/api/agent/summarizer`

## Testing
- `npm run lint`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_6881f4a846548327b9a70224c673d89c