### PR TITLE
feat: add summarizer instance and fix add logic

### DIFF
--- a/src/pages/Explore.jsx
+++ b/src/pages/Explore.jsx
@@ -35,6 +35,7 @@ function Explore() {
   ])
   const [selectedLink, setSelectedLink] = useState(null)
   const [userId, setUserId] = useState('')
+  const summarizer = useMemo(() => new SummarizerAgent(), [])
 
   useEffect(() => {
     let uid = localStorage.getItem(USER_ID_KEY)
@@ -75,14 +76,14 @@ function Explore() {
         console.error('Failed to parse links from localStorage', e)
       }
     }
-  }, [userId])
+  }, [userId, summarizer])
 
   async function handleAdd(data) {
     const base = normalizeItem(data, userId)
     const { summary } = await summarizer.run(base.url)
     const item = { ...base, summary }
     setLinks((prev) => {
-      const next = [...prev, normalizeItem(data, userId)]
+      const next = [...prev, item]
       localStorage.setItem('links', JSON.stringify(next))
       return next
     })


### PR DESCRIPTION
## Summary
- create `SummarizerAgent` instance with `useMemo`
- persist new summary data when adding cards
- add summarizer to effect dependencies

## Testing
- `npm run lint`
- `npm run dev` *(terminated after startup)*

------
https://chatgpt.com/codex/tasks/task_e_688206c8314c8327ad722122436e65be