### PR TITLE
Handle summarizer errors gracefully

### DIFF
--- a/src/pages/Explore.jsx
+++ b/src/pages/Explore.jsx
@@ -36,7 +36,6 @@ function Explore() {
   ])
   const [selectedLink, setSelectedLink] = useState(null)
   const [userId, setUserId] = useState('')
-  const summarizer = useMemo(() => new SummarizerAgent(), [])
 
   useEffect(() => {
     let uid = localStorage.getItem(USER_ID_KEY)
@@ -59,7 +58,12 @@ function Explore() {
                 updated.createdBy = userId
               }
               if (!updated.summary) {
-                const { summary } = await summarizer.run(updated.url)
+                let summary = ''
+                try {
+                  ;({ summary } = await summarizer.run(updated.url))
+                } catch (err) {
+                  console.warn('Summarizer failed for stored link', err)
+                }
                 updated.summary = summary
                 changed = true
               }
@@ -81,7 +85,12 @@ function Explore() {
 
   async function handleAdd(data) {
     const base = normalizeItem(data, userId)
-    const { summary } = await summarizer.run(base.url)
+    let summary = ''
+    try {
+      ;({ summary } = await summarizer.run(base.url))
+    } catch (err) {
+      console.warn('Summarizer failed when adding link', err)
+    }
     const item = { ...base, summary }
     setLinks((prev) => {
       const next = [...prev, item]


### PR DESCRIPTION
## Summary
- add try/catch around `summarizer.run` calls
- warn on error and default to an empty summary
- ensure stored links include a summary field

## Testing
- `npm run lint`
- `npm run dev` (started and showed local URLs)

------
https://chatgpt.com/codex/tasks/task_e_6882097af28c832789a1d91d2052a462