### PR TITLE
feat: add user id helper

### DIFF
--- a/src/pages/Explore.jsx
+++ b/src/pages/Explore.jsx
@@ -6,6 +6,13 @@ import SummarizerAgent from '../agents/SummarizerAgent.js'
 
 const USER_ID_KEY = 'userUuid'
 
+function generateUserId() {
+  if (crypto?.randomUUID) {
+    return crypto.randomUUID()
+  }
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`
+}
+
 function normalizeItem(data, userId) {
   return {
     url: data.url || data.link,
@@ -40,7 +47,7 @@ function Explore() {
   useEffect(() => {
     let uid = localStorage.getItem(USER_ID_KEY)
     if (!uid) {
-      uid = crypto.randomUUID()
+      uid = generateUserId()
       localStorage.setItem(USER_ID_KEY, uid)
     }
     setUserId(uid)


### PR DESCRIPTION
## Summary
- add `generateUserId` helper in Explore
- replace direct `crypto.randomUUID()` usage with the helper

## Testing
- `npm run lint`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_688209790f388327b6f4c394a153b7fd