### PR TITLE
feat: show preview card for selected link

### DIFF
--- a/src/pages/Explore.jsx
+++ b/src/pages/Explore.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useMemo } from 'react'
 import Header from '../components/Header.jsx'
 import UploadLinkBox from '../components/UploadLinkBox.jsx'
 import LinkCard from '../components/LinkCard.jsx'
+import PreviewCard from '../components/PreviewCard.jsx'
 import SummarizerAgent from '../agents/SummarizerAgent.js'
 
 const USER_ID_KEY = 'userUuid'
@@ -154,7 +155,7 @@ function Explore() {
           </div>
           <div className="w-full md:w-1/2 mt-6 md:mt-0">
             {selectedLink ? (
-              <LinkCard {...selectedLink} />
+              <PreviewCard selected {...selectedLink} />
             ) : (
               <div className="bg-gray-100 text-gray-500 flex items-center justify-center h-full p-6 rounded">
                 請選擇一個連結以預覽


### PR DESCRIPTION
## Summary
- show `PreviewCard` when a link is selected on Explore page

## Testing
- `npm run lint`
- `npm run dev` (startup check)

------
https://chatgpt.com/codex/tasks/task_e_68820ee5a0f08327b0fdb0e30cf426e3