### PR TITLE
Update LinkCard behavior

### DIFF
--- a/src/components/LinkCard.jsx
+++ b/src/components/LinkCard.jsx
@@ -1,12 +1,21 @@
 import React from 'react'
 
-function LinkCard({ title, description, summary, tags = [], url, onSelect, onDelete }) {
+function LinkCard({
+  title,
+  description,
+  summary,
+  tags = [],
+  url,
+  onSelect,
+  onDelete,
+  selected = false,
+}) {
   const displayTitle = title || '未命名'
   const displayTags = tags?.length > 0 ? tags : ['未分類']
 
   return (
     <div
-      className="bg-white p-2 md:p-4 rounded-lg shadow relative space-y-2 cursor-pointer text-sm md:text-base group"
+      className="bg-white p-2 md:p-4 rounded-lg shadow relative space-y-2 cursor-pointer text-sm md:text-base"
       onClick={onSelect}
     >
       {onDelete && (
@@ -41,7 +50,9 @@ function LinkCard({ title, description, summary, tags = [], url, onSelect, onDel
         前往連結
       </a>
       {summary && (
-        <div className="pointer-events-none absolute inset-0 hidden group-hover:flex items-center justify-center bg-black bg-opacity-60 text-white text-xs p-4 rounded-lg">
+        <div
+          className={`pointer-events-none absolute inset-0 ${selected ? 'flex' : 'hidden'} items-center justify-center bg-black bg-opacity-60 text-white text-xs p-4 rounded-lg`}
+        >
           <p>{summary}</p>
         </div>
       )}

--- a/src/pages/Explore.jsx
+++ b/src/pages/Explore.jsx
@@ -131,6 +131,7 @@ function Explore() {
       <LinkCard
         key={link.url}
         {...link}
+        selected={selectedLink?.url === link.url}
         onSelect={() => setSelectedLink(link)}
         onDelete={allowDelete ? handleDelete : undefined}
       />
@@ -154,7 +155,7 @@ function Explore() {
           </div>
           <div className="w-full md:w-1/2 mt-6 md:mt-0">
             {selectedLink ? (
-              <LinkCard {...selectedLink} />
+              <LinkCard {...selectedLink} selected />
             ) : (
               <div className="bg-gray-100 text-gray-500 flex items-center justify-center h-full p-6 rounded">
                 請選擇一個連結以預覽


### PR DESCRIPTION
## Summary
- toggle summary display via new `selected` prop
- highlight summary overlay in Explore when card is chosen

## Testing
- `npm run lint`
- `npm run dev` *(terminated after startup)*

------
https://chatgpt.com/codex/tasks/task_e_68820ee123488327ae5fca7433406abc