### PR TITLE
feat: 加入 selected 狀態顯示摘要

### DIFF
--- a/src/components/LinkCard.jsx
+++ b/src/components/LinkCard.jsx
@@ -1,6 +1,15 @@
 import React from 'react'
 
-function LinkCard({ title, description, summary, tags = [], url, onSelect, onDelete }) {
+function LinkCard({
+  title,
+  description,
+  summary,
+  tags = [],
+  url,
+  onSelect,
+  onDelete,
+  selected = false,
+}) {
   const displayTitle = title || '未命名'
   const displayTags = tags?.length > 0 ? tags : ['未分類']
 
@@ -41,8 +50,10 @@ function LinkCard({ title, description, summary, tags = [], url, onSelect, onDel
         前往連結
       </a>
       {summary && (
-        <div className="pointer-events-none absolute inset-0 hidden group-hover:flex items-center justify-center bg-black bg-opacity-60 text-white text-xs p-4 rounded-lg">
-          <p>{summary}</p>
+        <div
+          className={`pointer-events-none absolute inset-0 flex items-center justify-center bg-black bg-opacity-60 text-white text-xs p-4 rounded-lg transition-opacity duration-500 ${selected ? 'opacity-100' : 'opacity-0'}`}
+        >
+          {selected && <p>{summary}</p>}
         </div>
       )}
     </div>

--- a/src/pages/Explore.jsx
+++ b/src/pages/Explore.jsx
@@ -131,6 +131,7 @@ function Explore() {
       <LinkCard
         key={link.url}
         {...link}
+        selected={selectedLink && selectedLink.url === link.url}
         onSelect={() => setSelectedLink(link)}
         onDelete={allowDelete ? handleDelete : undefined}
       />
@@ -154,8 +155,8 @@ function Explore() {
           </div>
           <div className="w-full md:w-1/2 mt-6 md:mt-0">
             {selectedLink ? (
-              <LinkCard {...selectedLink} />
-            ) : (
+              <LinkCard {...selectedLink} selected />
+              ) : (
               <div className="bg-gray-100 text-gray-500 flex items-center justify-center h-full p-6 rounded">
                 請選擇一個連結以預覽
               </div>


### PR DESCRIPTION
## Summary
- add `selected` prop to `LinkCard`
- fade in summary only when card is selected
- pass `selected` flag from Explore page

## Testing
- `npm run lint`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_68820ee2aff883279a265b4386b36fe5