### PR TITLE
Add text sanitizer for preview cards

### DIFF
--- a/src/components/PreviewCard.jsx
+++ b/src/components/PreviewCard.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react'
+import cleanText from '../lib/cleanText.js'
 
 function PreviewCard({ title, description, tags = [], url }) {
   const [visible, setVisible] = useState(false)
@@ -16,7 +17,7 @@ function PreviewCard({ title, description, tags = [], url }) {
       className={`bg-white p-4 rounded-lg shadow space-y-2 transition-opacity duration-500 ${visible ? 'opacity-100' : 'opacity-0'}`}
     >
       <h2 className="text-xl font-semibold text-black">{displayTitle}</h2>
-      <p className="text-gray-700">{description}</p>
+      <p className="text-gray-700 whitespace-pre-line">{cleanText(description)}</p>
       <div className="flex flex-wrap gap-2">
         {displayTags.map((tag) => (
           <span

--- a/src/lib/cleanText.js
+++ b/src/lib/cleanText.js
@@ -1,0 +1,15 @@
+export default function cleanText(input = '') {
+  const withBreaks = input
+    .replace(/<br\s*\/?>/gi, '\n')
+    .replace(/<\/p>/gi, '\n')
+  const stripped = withBreaks.replace(/<[^>]+>/g, '')
+  const entities = {
+    '&amp;': '&',
+    '&lt;': '<',
+    '&gt;': '>',
+    '&quot;': '"',
+    '&#39;': "'",
+    '&nbsp;': ' '
+  }
+  return stripped.replace(/&(amp|lt|gt|quot|#39|nbsp);/g, (m) => entities[m])
+}


### PR DESCRIPTION
## Summary
- create `cleanText` utility
- sanitize descriptions in `PreviewCard`
- verify app start and lint pass

## Testing
- `npm run dev`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68820ee40abc832784e4415d82ba0c7d