### PR TITLE
Add unique IDs for item deletion

### DIFF
--- a/src/components/LinkCard.jsx
+++ b/src/components/LinkCard.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 function LinkCard({
+  id,
   title,
   description,
   summary,
@@ -31,7 +32,7 @@ function LinkCard({
           className="absolute top-2 right-2 text-red-500"
           onClick={(e) => {
             e.stopPropagation()
-            onDelete(url)
+            onDelete(id)
           }}
         >
           🗑️


### PR DESCRIPTION
## Summary
- generate unique item IDs when normalizing link data
- include the ID when rendering `LinkCard`
- delete items by ID instead of URL

## Testing
- `npm run lint`
- `npm run dev` *(terminated after startup)*

------
https://chatgpt.com/codex/tasks/task_e_688210a3831c8327b5f1b27f36c122b6