### PR TITLE
Integrate PreviewCard into Explore

### DIFF
--- a/src/components/PreviewCard.jsx
+++ b/src/components/PreviewCard.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react'
 
-function PreviewCard({ title, description, tags = [], url }) {
+function PreviewCard({ title, description, summary, tags = [], url }) {
   const [visible, setVisible] = useState(false)
 
   useEffect(() => {
@@ -9,6 +9,7 @@ function PreviewCard({ title, description, tags = [], url }) {
   }, [])
 
   const displayTitle = title || '未命名'
+  const displayText = summary || description
   const displayTags = Array.isArray(tags) && tags.length > 0 ? tags : ['未分類']
 
   return (
@@ -16,7 +17,9 @@ function PreviewCard({ title, description, tags = [], url }) {
       className={`bg-white p-4 rounded-lg shadow space-y-2 transition-opacity duration-500 ${visible ? 'opacity-100' : 'opacity-0'}`}
     >
       <h2 className="text-xl font-semibold text-black">{displayTitle}</h2>
-      <p className="text-gray-700">{description}</p>
+      {displayText && (
+        <p className="text-gray-700 whitespace-pre-line">{displayText}</p>
+      )}
       <div className="flex flex-wrap gap-2">
         {displayTags.map((tag) => (
           <span

--- a/src/pages/Explore.jsx
+++ b/src/pages/Explore.jsx
@@ -156,8 +156,8 @@ function Explore() {
           </div>
           <div className="w-full md:w-1/2 mt-6 md:mt-0">
             {selectedLink ? (
-              <LinkCard {...selectedLink} selected />
-              ) : (
+              <PreviewCard {...selectedLink} />
+            ) : (
               <div className="bg-gray-100 text-gray-500 flex items-center justify-center h-full p-6 rounded">
                 請選擇一個連結以預覽
               </div>


### PR DESCRIPTION
## Summary
- display PreviewCard when a link is selected
- allow PreviewCard to show summary or description text

## Testing
- `npm run lint`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_688210a25bfc83279ca0670e874cc066