### PR TITLE
feat: strip script/style tags before summarizing

### DIFF
--- a/src/agents/SummarizerAgent.js
+++ b/src/agents/SummarizerAgent.js
@@ -13,7 +13,9 @@ export default class SummarizerAgent {
       try {
         const res = await fetch(link)
         const html = await res.text()
-        text = html.replace(/<[^>]*>/g, ' ')
+        const noScripts = html.replace(/<script[^>]*>[\s\S]*?<\/script>/gi, ' ')
+        const noStyles = noScripts.replace(/<style[^>]*>[\s\S]*?<\/style>/gi, ' ')
+        text = noStyles.replace(/<[^>]*>/g, ' ')
       } catch {
         // ignore fetch errors
       }

--- a/src/components/PreviewCard.jsx
+++ b/src/components/PreviewCard.jsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from 'react'
-import cleanText from '../lib/cleanText.js'
 
 function PreviewCard({ title, description, summary, tags = [], url }) {
   const [visible, setVisible] = useState(false)


### PR DESCRIPTION
## Summary
- strip `<script>` and `<style>` blocks before other HTML tags in `SummarizerAgent`
- tidy lint error in `PreviewCard`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688213e3a6f88327a2e8e9b82dea4da2