### PR TITLE
Fix unused import

### DIFF
--- a/src/components/PreviewCard.jsx
+++ b/src/components/PreviewCard.jsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from 'react'
-import cleanText from '../lib/cleanText.js'
 
 function PreviewCard({ title, description, summary, tags = [], url }) {
   const [visible, setVisible] = useState(false)


### PR DESCRIPTION
## Summary
- remove unused cleanText import from PreviewCard

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688213e528cc832795be5bcf75614ed3