### PR TITLE
feat: load sample links

### DIFF
--- a/src/components/PreviewCard.jsx
+++ b/src/components/PreviewCard.jsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from 'react'
-import cleanText from '../lib/cleanText.js'
 
 function PreviewCard({ title, description, summary, tags = [], url }) {
   const [visible, setVisible] = useState(false)


### PR DESCRIPTION
## Summary
- add constant `SAMPLE_LINKS` with two demo links
- use the samples when no stored links exist
- remove unused import in `PreviewCard`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688213e5ad308327bffabb5603897bb6