### PR TITLE
feat: add tag filter component

### DIFF
--- a/src/components/TagFilter.jsx
+++ b/src/components/TagFilter.jsx
@@ -1,0 +1,36 @@
+import React from 'react'
+
+function TagFilter({ tags = [], selected = [], onChange, mode = 'multi' }) {
+  function handleClick(tag) {
+    if (!onChange) return
+    if (mode === 'single') {
+      if (selected.includes(tag)) onChange([])
+      else onChange([tag])
+    } else {
+      if (selected.includes(tag)) onChange(selected.filter((t) => t !== tag))
+      else onChange([...selected, tag])
+    }
+  }
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      {tags.map((tag) => {
+        const active = selected.includes(tag)
+        return (
+          <button
+            key={tag}
+            type="button"
+            onClick={() => handleClick(tag)}
+            className={`px-2 py-1 rounded text-sm ${
+              active ? 'bg-blue-500 text-white' : 'bg-blue-100 text-blue-800'
+            }`}
+          >
+            #{tag}
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+
+export default TagFilter

--- a/src/pages/Explore.jsx
+++ b/src/pages/Explore.jsx
@@ -3,6 +3,7 @@ import Header from '../components/Header.jsx'
 import UploadLinkBox from '../components/UploadLinkBox.jsx'
 import LinkCard from '../components/LinkCard.jsx'
 import PreviewCard from '../components/PreviewCard.jsx'
+import TagFilter from '../components/TagFilter.jsx'
 import SummarizerAgent from '../agents/SummarizerAgent.js'
 
 const USER_ID_KEY = 'userUuid'
@@ -53,6 +54,11 @@ function Explore() {
   const [links, setLinks] = useState([])
   const [selectedLink, setSelectedLink] = useState(null)
   const [userId, setUserId] = useState('')
+  const [selectedTags, setSelectedTags] = useState([])
+  const availableTags = useMemo(
+    () => [...new Set(links.flatMap((l) => l.tags))],
+    [links]
+  )
 
   // ✨ 第一次載入時，初始化 userId
   useEffect(() => {
@@ -162,6 +168,13 @@ function Explore() {
     )
   }
 
+  const filteredLinks = useMemo(() => {
+    if (selectedTags.length === 0) return links
+    return links.filter((link) =>
+      selectedTags.every((tag) => link.tags.includes(tag))
+    )
+  }, [links, selectedTags])
+
   return (
     <div className="min-h-screen bg-gray-50 flex justify-center items-start px-6 py-8 overflow-x-hidden">
       <div className="container mx-auto px-4 space-y-6">
@@ -169,9 +182,15 @@ function Explore() {
         <div className="flex flex-col md:flex-row gap-6">
           <div className="w-full md:w-1/2 space-y-6">
             <UploadLinkBox onAdd={handleAdd} />
+            <TagFilter
+              tags={availableTags}
+              selected={selectedTags}
+              mode="multi"
+              onChange={setSelectedTags}
+            />
             <div className="space-y-6">
-              {links.length > 0 ? (
-                links.map((link) => renderListItem(link))
+              {filteredLinks.length > 0 ? (
+                filteredLinks.map((link) => renderListItem(link))
               ) : (
                 <p className="text-center text-gray-500">尚無連結，請貼上新網址</p>
               )}


### PR DESCRIPTION
## Summary
- add reusable `TagFilter` component for single or multi tag selection
- integrate tag filtering into Explore page and filter link cards by chosen tags

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68996f7969048327bccb771e29b83742