### PR TITLE
feat: enable tag filtering

### DIFF
--- a/src/components/LinkCard.jsx
+++ b/src/components/LinkCard.jsx
@@ -10,6 +10,7 @@ function LinkCard({
   onSelect,
   onDelete,
   selected = false,
+  onTagSelect,
 }) {
   const displayTitle = title || '未命名'
   const displayTags = tags?.length > 0 ? tags : ['未分類']
@@ -53,12 +54,17 @@ function LinkCard({
       {/* 標籤 */}
       <div className="flex flex-wrap gap-2">
         {displayTags.map((tag) => (
-          <span
+          <button
             key={tag}
+            type="button"
             className="px-2 py-1 bg-blue-100 text-blue-800 rounded text-sm"
+            onClick={(e) => {
+              e.stopPropagation()
+              onTagSelect?.(tag)
+            }}
           >
             #{tag}
-          </span>
+          </button>
         ))}
       </div>
 

--- a/src/components/PreviewCard.jsx
+++ b/src/components/PreviewCard.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react'
 
-function PreviewCard({ title, description, summary, tags = [], url }) {
+function PreviewCard({ title, description, summary, tags = [], url, onTagSelect }) {
   const [visible, setVisible] = useState(false)
 
   useEffect(() => {
@@ -22,12 +22,17 @@ function PreviewCard({ title, description, summary, tags = [], url }) {
       )}
       <div className="flex flex-wrap gap-2">
         {displayTags.map((tag) => (
-          <span
+          <button
             key={tag}
+            type="button"
             className="px-2 py-1 bg-blue-100 text-blue-800 rounded text-sm"
+            onClick={(e) => {
+              e.stopPropagation()
+              onTagSelect?.(tag)
+            }}
           >
             #{tag}
-          </span>
+          </button>
         ))}
       </div>
       <a

--- a/src/components/TagFilter.jsx
+++ b/src/components/TagFilter.jsx
@@ -1,0 +1,22 @@
+import React from 'react'
+
+function TagFilter({ tags = [], onToggle }) {
+  if (!tags || tags.length === 0) return null
+
+  return (
+    <div className="flex flex-wrap gap-2 mb-4">
+      {tags.map((tag) => (
+        <button
+          key={tag}
+          type="button"
+          className="px-2 py-1 bg-blue-200 text-blue-800 rounded text-sm"
+          onClick={() => onToggle(tag)}
+        >
+          #{tag} ✕
+        </button>
+      ))}
+    </div>
+  )
+}
+
+export default TagFilter


### PR DESCRIPTION
## Summary
- allow LinkCard and PreviewCard tag chips to trigger optional onTagSelect handlers
- add TagFilter component and tag-based filtering to Explore page

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689970a327d083279ba6ac40d9cb9ae9