### PR TITLE
feat: track link creation time

### DIFF
--- a/src/pages/Explore.jsx
+++ b/src/pages/Explore.jsx
@@ -46,6 +46,7 @@ function normalizeItem(data, userId) {
     language: data.language || 'unknown',
     description: data.description || '',
     createdBy: data.createdBy || userId,
+    createdAt: data.createdAt || Date.now(),
   }
 }
 
@@ -79,6 +80,7 @@ function Explore() {
       const normalized = await Promise.all(
         items.map(async (item) => {
           let updated = normalizeItem(item, userId)
+          if (!item.createdAt) changed = true
 
           if (!updated.summary) {
             try {
@@ -132,7 +134,7 @@ function Explore() {
       summary = '（暫無摘要）'
     }
 
-    const item = { ...base, summary }
+    const item = { ...base, summary, createdAt: base.createdAt }
 
     setLinks((prev) => {
       const next = [...prev, item]


### PR DESCRIPTION
## Summary
- add `createdAt` timestamp during link normalization
- ensure new links and stored items persist `createdAt`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899734e9dd88327990f1b8a9c9f686e