### PR TITLE
feat: add stats panel

### DIFF
--- a/src/components/StatsPanel.jsx
+++ b/src/components/StatsPanel.jsx
@@ -1,0 +1,57 @@
+import React, { useMemo } from 'react'
+
+function StatsPanel({ links = [], position = 'top-right' }) {
+  const weeklyCount = useMemo(() => {
+    const now = Date.now()
+    const weekAgo = now - 7 * 24 * 60 * 60 * 1000
+    return links.filter((l) => {
+      if (!l.createdAt) return false
+      return new Date(l.createdAt).getTime() >= weekAgo
+    }).length
+  }, [links])
+
+  const topTags = useMemo(() => {
+    const counts = links.reduce((acc, link) => {
+      if (Array.isArray(link.tags)) {
+        link.tags.forEach((tag) => {
+          acc[tag] = (acc[tag] || 0) + 1
+        })
+      }
+      return acc
+    }, {})
+
+    return Object.entries(counts)
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 5)
+  }, [links])
+
+  const containerClasses =
+    position === 'footer'
+      ? 'bg-white shadow rounded p-4 w-full'
+      : 'bg-white shadow rounded p-4 md:w-64 md:ml-auto'
+
+  return (
+    <div className={containerClasses}>
+      <h2 className="text-lg font-semibold mb-2">統計資訊</h2>
+      <p className="mb-4">本週新增數：{weeklyCount}</p>
+      <div>
+        <h3 className="font-semibold mb-1">熱門標籤</h3>
+        {topTags.length > 0 ? (
+          <ul className="space-y-1">
+            {topTags.map(([tag, count]) => (
+              <li key={tag} className="flex justify-between">
+                <span>{tag}</span>
+                <span>{count}</span>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="text-gray-500">尚無標籤</p>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default StatsPanel
+

--- a/src/pages/Explore.jsx
+++ b/src/pages/Explore.jsx
@@ -5,6 +5,7 @@ import LinkCard from '../components/LinkCard.jsx'
 import PreviewCard from '../components/PreviewCard.jsx'
 import TagFilter from '../components/TagFilter.jsx'
 import SummarizerAgent from '../agents/SummarizerAgent.js'
+import StatsPanel from '../components/StatsPanel.jsx'
 
 const USER_ID_KEY = 'userUuid'
 
@@ -46,6 +47,7 @@ function normalizeItem(data, userId) {
     language: data.language || 'unknown',
     description: data.description || '',
     createdBy: data.createdBy || userId,
+    createdAt: data.createdAt || new Date().toISOString(),
   }
 }
 
@@ -178,7 +180,10 @@ function Explore() {
   return (
     <div className="min-h-screen bg-gray-50 flex justify-center items-start px-6 py-8 overflow-x-hidden">
       <div className="container mx-auto px-4 space-y-6">
-        <Header />
+        <div className="flex justify-between items-start">
+          <Header />
+          <StatsPanel links={links} />
+        </div>
         <div className="flex flex-col md:flex-row gap-6">
           <div className="w-full md:w-1/2 space-y-6">
             <UploadLinkBox onAdd={handleAdd} />


### PR DESCRIPTION
## Summary
- add stats panel for recent links and popular tags
- track createdAt for links
- show stats beside header on explore page

## Testing
- `npm run lint`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_6899735233f0832788253551c07911f0