### PR TITLE
feat: enable tag selection from cards

### DIFF
--- a/src/components/LinkCard.jsx
+++ b/src/components/LinkCard.jsx
@@ -10,6 +10,7 @@ function LinkCard({
   onSelect,
   onDelete,
   selected = false,
+  onTagSelect,
 }) {
   const displayTitle = title || '未命名'
   const displayTags = tags?.length > 0 ? tags : ['未分類']
@@ -53,12 +54,17 @@ function LinkCard({
       {/* 標籤 */}
       <div className="flex flex-wrap gap-2">
         {displayTags.map((tag) => (
-          <span
+          <button
+            type="button"
             key={tag}
             className="px-2 py-1 bg-blue-100 text-blue-800 rounded text-sm"
+            onClick={(e) => {
+              e.stopPropagation()
+              onTagSelect?.(tag)
+            }}
           >
             #{tag}
-          </span>
+          </button>
         ))}
       </div>
 

--- a/src/components/PreviewCard.jsx
+++ b/src/components/PreviewCard.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react'
 
-function PreviewCard({ title, description, summary, tags = [], url }) {
+function PreviewCard({ title, description, summary, tags = [], url, onTagSelect }) {
   const [visible, setVisible] = useState(false)
 
   useEffect(() => {
@@ -22,12 +22,17 @@ function PreviewCard({ title, description, summary, tags = [], url }) {
       )}
       <div className="flex flex-wrap gap-2">
         {displayTags.map((tag) => (
-          <span
+          <button
+            type="button"
             key={tag}
             className="px-2 py-1 bg-blue-100 text-blue-800 rounded text-sm"
+            onClick={(e) => {
+              e.stopPropagation()
+              onTagSelect?.(tag)
+            }}
           >
             #{tag}
-          </span>
+          </button>
         ))}
       </div>
       <a

--- a/src/pages/Explore.jsx
+++ b/src/pages/Explore.jsx
@@ -154,6 +154,12 @@ function Explore() {
     }
   }
 
+  function handleTagSelect(tag) {
+    setSelectedTags((prev) =>
+      prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag]
+    )
+  }
+
   // 🧩 渲染每一筆連結卡片
   function renderListItem(link) {
     const allowDelete = link.createdBy === userId
@@ -164,6 +170,7 @@ function Explore() {
         selected={selectedLink && selectedLink.id === link.id}
         onSelect={() => setSelectedLink(link)}
         onDelete={allowDelete ? handleDelete : undefined}
+        onTagSelect={handleTagSelect}
       />
     )
   }
@@ -198,7 +205,7 @@ function Explore() {
           </div>
           <div className="w-full md:w-1/2 mt-6 md:mt-0">
             {selectedLink ? (
-              <PreviewCard {...selectedLink} />
+              <PreviewCard {...selectedLink} onTagSelect={handleTagSelect} />
             ) : (
               <div className="bg-gray-100 text-gray-500 flex items-center justify-center h-full p-6 rounded">
                 請選擇一個連結以預覽


### PR DESCRIPTION
## Summary
- allow `LinkCard` and `PreviewCard` to accept optional `onTagSelect` callbacks
- propagate tag clicks from `Explore` to update selected filters

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689973a0753c83278b5db50d8c1072a2