### PR TITLE
feat: add sticky header with mobile scrolling

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -3,19 +3,21 @@ import { NavLink } from 'react-router-dom'
 
 function Header() {
   const tabClass = ({ isActive }) =>
-    `px-4 py-2 rounded-md text-sm font-medium transition-colors ${
+    `px-4 py-3 rounded-md text-sm font-medium transition-colors ${
       isActive ? 'bg-blue-500 text-white' : 'text-gray-600 hover:bg-gray-200'
     }`
 
   return (
-    <nav className="flex justify-center gap-4">
-      <NavLink to="/explore" className={tabClass}>
-        Explore
-      </NavLink>
-      <NavLink to="/" end className={tabClass}>
-        My Links
-      </NavLink>
-    </nav>
+    <header className="sticky top-0 z-20 bg-white/70 backdrop-blur">
+      <nav className="flex gap-4 overflow-x-auto whitespace-nowrap px-4">
+        <NavLink to="/explore" className={tabClass}>
+          Explore
+        </NavLink>
+        <NavLink to="/" end className={tabClass}>
+          My Links
+        </NavLink>
+      </nav>
+    </header>
   )
 }
 

--- a/src/pages/Explore.jsx
+++ b/src/pages/Explore.jsx
@@ -6,7 +6,6 @@ import PreviewCard from '../components/PreviewCard.jsx'
 import TagFilter from '../components/TagFilter.jsx'
 import SummarizerAgent from '../agents/SummarizerAgent.js'
 import StatsPanel from '../components/StatsPanel.jsx'
-import NavTabs from '../components/NavTabs.jsx'
 
 const USER_ID_KEY = 'userUuid'
 
@@ -193,7 +192,6 @@ function Explore() {
           <Header />
           <StatsPanel links={links} />
         </div>
-        <NavTabs />
         <div className="flex flex-col md:flex-row gap-6">
           <div className="w-full md:w-1/2 space-y-6">
             <UploadLinkBox onAdd={handleAdd} />

--- a/src/pages/MyLinks.jsx
+++ b/src/pages/MyLinks.jsx
@@ -6,7 +6,6 @@ import PreviewCard from '../components/PreviewCard.jsx'
 import TagFilter from '../components/TagFilter.jsx'
 import SummarizerAgent from '../agents/SummarizerAgent.js'
 import StatsPanel from '../components/StatsPanel.jsx'
-import NavTabs from '../components/NavTabs.jsx'
 import Sortable from 'sortablejs'
 
 const USER_ID_KEY = 'userUuid'
@@ -191,9 +190,6 @@ function MyLinks() {
           <Header />
           <StatsPanel links={links} />
         </div>
-
-        <NavTabs />
-
         <div className="flex flex-col md:flex-row gap-6">
           <div className="w-full md:w-1/2 space-y-6">
             <UploadLinkBox onAdd={handleAdd} />


### PR DESCRIPTION
## Summary
- wrap nav in a sticky header with blurred background and horizontal scrolling
- drop NavTabs usage from page components so header handles navigation

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68997de9c04c8327801ea680e82d0454