### PR TITLE
feat: add tag toolbar and sticky preview

### DIFF
--- a/src/pages/MyLinks.jsx
+++ b/src/pages/MyLinks.jsx
@@ -36,6 +36,7 @@ function normalizeItem(data, userId) {
 }
 
 function MyLinks() {
+  const isPublic = false
   const summarizer = useMemo(() => new SummarizerAgent(), [])
   const [links, setLinks] = useState([])
   const [selectedLink, setSelectedLink] = useState(null)
@@ -189,21 +190,35 @@ function MyLinks() {
       <div className="container mx-auto px-4 space-y-6">
         <div className="flex justify-between items-start">
           <Header />
-          <StatsPanel links={links} />
+          {!isPublic && <StatsPanel links={links} compact />}
         </div>
 
         <NavTabs />
 
         <div className="flex flex-col md:flex-row gap-6">
-          <div className="w-full md:w-1/2 space-y-6">
+          <div className="w-full md:w-7/12 space-y-6">
             <UploadLinkBox onAdd={handleAdd} />
 
-            <TagFilter
-              tags={availableTags}
-              selected={selectedTags}
-              mode="multi"
-              onChange={setSelectedTags}
-            />
+            <div className="space-y-4">
+              <div className="flex items-center justify-between">
+                <span className="text-sm text-gray-600">
+                  已選 {selectedTags.length} 個
+                </span>
+                <button
+                  className="text-sm text-blue-500 hover:underline"
+                  onClick={() => setSelectedTags([])}
+                >
+                  清除
+                </button>
+              </div>
+
+              <TagFilter
+                tags={availableTags}
+                selected={selectedTags}
+                mode="multi"
+                onChange={setSelectedTags}
+              />
+            </div>
 
             <div className="space-y-6" ref={listRef}>
               {filteredLinks.length > 0 ? (
@@ -214,7 +229,7 @@ function MyLinks() {
             </div>
           </div>
 
-          <div className="w-full md:w-1/2 mt-6 md:mt-0">
+          <div className="w-full md:w-5/12 md:sticky md:top-24 self-start mt-6 md:mt-0">
             {selectedLink ? (
               <PreviewCard {...selectedLink} onTagSelect={handleTagSelect} />
             ) : (


### PR DESCRIPTION
## Summary
- add `isPublic` flag and hide stats for public views
- add tag selection toolbar with clear action
- make preview panel sticky and adjust column widths

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68997df250f88327852babab36c866c7