### PR TITLE
feat: refine explore page layout

### DIFF
--- a/src/pages/Explore.jsx
+++ b/src/pages/Explore.jsx
@@ -9,6 +9,7 @@ import StatsPanel from '../components/StatsPanel.jsx'
 import NavTabs from '../components/NavTabs.jsx'
 
 const USER_ID_KEY = 'userUuid'
+const isPublic = true
 
 const SAMPLE_LINKS = [
   {
@@ -191,12 +192,24 @@ function Explore() {
       <div className="container mx-auto px-4 space-y-6">
         <div className="flex justify-between items-start">
           <Header />
-          <StatsPanel links={links} />
+          {!isPublic && <StatsPanel links={links} compact />}
         </div>
         <NavTabs />
         <div className="flex flex-col md:flex-row gap-6">
-          <div className="w-full md:w-1/2 space-y-6">
+          <div className="w-full md:w-7/12 space-y-6">
             <UploadLinkBox onAdd={handleAdd} />
+            {selectedTags.length > 0 && (
+              <div className="flex items-center justify-between text-sm text-gray-600">
+                <span>已選 {selectedTags.length} 個標籤</span>
+                <button
+                  type="button"
+                  onClick={() => setSelectedTags([])}
+                  className="text-blue-600 hover:underline"
+                >
+                  清除
+                </button>
+              </div>
+            )}
             <TagFilter
               tags={availableTags}
               selected={selectedTags}
@@ -211,7 +224,7 @@ function Explore() {
               )}
             </div>
           </div>
-          <div className="w-full md:w-1/2 mt-6 md:mt-0">
+          <div className="w-full md:w-5/12 mt-6 md:mt-0 md:sticky md:top-24 self-start">
             {selectedLink ? (
               <PreviewCard {...selectedLink} onTagSelect={handleTagSelect} />
             ) : (


### PR DESCRIPTION
## Summary
- add `isPublic` flag to Explore page
- show StatsPanel only for private view and pass compact prop
- add toolbar to display selected tags count with clear action
- adjust Explore layout to 7/12 and 5/12 columns with sticky preview

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68997df4dd0c83279de74469a6d1b415