### PR TITLE
refactor: lazy load StatsPanel

### DIFF
--- a/src/pages/Explore.jsx
+++ b/src/pages/Explore.jsx
@@ -5,10 +5,14 @@ import LinkCard from '../components/LinkCard.jsx'
 import PreviewCard from '../components/PreviewCard.jsx'
 import TagFilter from '../components/TagFilter.jsx'
 import SummarizerAgent from '../agents/SummarizerAgent.js'
-import StatsPanel from '../components/StatsPanel.jsx'
 import NavTabs from '../components/NavTabs.jsx'
 
 const USER_ID_KEY = 'userUuid'
+
+const isPublic = import.meta.env.MODE === 'public'
+const StatsPanel = !isPublic
+  ? React.lazy(() => import('../components/StatsPanel.jsx'))
+  : null
 
 const SAMPLE_LINKS = [
   {
@@ -191,7 +195,11 @@ function Explore() {
       <div className="container mx-auto px-4 space-y-6">
         <div className="flex justify-between items-start">
           <Header />
-          <StatsPanel links={links} />
+          {!isPublic && StatsPanel && (
+            <React.Suspense fallback={null}>
+              <StatsPanel links={links} />
+            </React.Suspense>
+          )}
         </div>
         <NavTabs />
         <div className="flex flex-col md:flex-row gap-6">

--- a/src/pages/MyLinks.jsx
+++ b/src/pages/MyLinks.jsx
@@ -5,11 +5,15 @@ import LinkCard from '../components/LinkCard.jsx'
 import PreviewCard from '../components/PreviewCard.jsx'
 import TagFilter from '../components/TagFilter.jsx'
 import SummarizerAgent from '../agents/SummarizerAgent.js'
-import StatsPanel from '../components/StatsPanel.jsx'
 import NavTabs from '../components/NavTabs.jsx'
 import Sortable from 'sortablejs'
 
 const USER_ID_KEY = 'userUuid'
+
+const isPublic = import.meta.env.MODE === 'public'
+const StatsPanel = !isPublic
+  ? React.lazy(() => import('../components/StatsPanel.jsx'))
+  : null
 
 function generateItemId() {
   if (crypto?.randomUUID) return crypto.randomUUID()
@@ -189,7 +193,11 @@ function MyLinks() {
       <div className="container mx-auto px-4 space-y-6">
         <div className="flex justify-between items-start">
           <Header />
-          <StatsPanel links={links} />
+          {!isPublic && StatsPanel && (
+            <React.Suspense fallback={null}>
+              <StatsPanel links={links} />
+            </React.Suspense>
+          )}
         </div>
 
         <NavTabs />


### PR DESCRIPTION
## Summary
- lazy load `StatsPanel` in MyLinks and Explore pages
- avoid rendering `StatsPanel` when app runs in public mode

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68997df94608832781873e74645cc2b3