### PR TITLE
refactor: centralize tag selection UI

### DIFF
--- a/src/agents/TaggerAgent.js
+++ b/src/agents/TaggerAgent.js
@@ -48,7 +48,7 @@ export default class TaggerAgent {
         const noScripts = html.replace(/<script[^>]*>[\s\S]*?<\/script>/gi, ' ')
         const noStyles  = noScripts.replace(/<style[^>]*>[\s\S]*?<\/style>/gi, ' ')
         text = noStyles.replace(/<[^>]*>/g, ' ')
-      } catch (e) {
+      } catch {
         // 忽略 fetch 失敗；維持空字串
       }
     }

--- a/src/components/TagFilter.jsx
+++ b/src/components/TagFilter.jsx
@@ -19,7 +19,7 @@ function TagFilter({ tags = [], selected = [], onChange, mode = 'multi' }) {
   return (
     <div>
       <div className="flex items-center gap-2 mb-2">
-        <span data-testid="selected-count">已選擇 {selected.length} 個標籤</span>
+        <span data-testid="selected-count">已選 {selected.length} 個標籤</span>
         {selected.length > 0 && (
           <button
             type="button"

--- a/src/components/UploadLinkBox.jsx
+++ b/src/components/UploadLinkBox.jsx
@@ -43,7 +43,7 @@ export default function UploadLinkBox({ onAdd }) {
           uniq.push({ tag: key, selected: s.selected !== false });
         }
         setSuggestions(uniq);
-      } catch (err) {
+      } catch {
         // 靜默失敗：清空建議避免干擾使用者
         setSuggestions([]);
         // console.error(err);

--- a/src/pages/Explore.jsx
+++ b/src/pages/Explore.jsx
@@ -182,25 +182,14 @@ function Explore() {
           <div className="w-full md:w-7/12 space-y-6">
             <UploadLinkBox onAdd={handleAdd} />
 
-            <div className="flex items-center justify-between">
-              <span className="text-sm text-gray-500">已選 {selectedTags.length}</span>
-              {selectedTags.length > 0 && (
-                <button
-                  type="button"
-                  onClick={() => setSelectedTags([])}
-                  className="text-sm text-blue-600 hover:underline"
-                >
-                  清除
-                </button>
-              )}
+            <div className="mt-2">
+              <TagFilter
+                tags={availableTags}
+                selected={selectedTags}
+                mode="multi"
+                onChange={setSelectedTags}
+              />
             </div>
-
-            <TagFilter
-              tags={availableTags}
-              selected={selectedTags}
-              mode="multi"
-              onChange={setSelectedTags}
-            />
 
             <div className="space-y-6">
               {filteredLinks.length > 0

--- a/src/pages/MyLinks.jsx
+++ b/src/pages/MyLinks.jsx
@@ -210,21 +210,7 @@ function MyLinks() {
           <div className="w-full md:w-7/12 space-y-6">
             <UploadLinkBox onAdd={handleAdd} />
 
-            <div className="space-y-4">
-              <div className="flex items-center justify-between">
-                <span className="text-sm text-gray-600">
-                  已選 {selectedTags.length} 個
-                </span>
-                {selectedTags.length > 0 && (
-                  <button
-                    className="text-sm text-blue-500 hover:underline"
-                    onClick={() => setSelectedTags([])}
-                  >
-                    清除
-                  </button>
-                )}
-              </div>
-
+            <div className="mt-2">
               <TagFilter
                 tags={availableTags}
                 selected={selectedTags}


### PR DESCRIPTION
## Summary
- show selected tag count and clear button within TagFilter
- remove redundant selection blocks from MyLinks and Explore
- clean up unused variables to satisfy lint

## Testing
- `npm run lint`
- `npm test` *(fails: TaggerAgent and UploadLinkBox tests expect functionality not implemented)*

------
https://chatgpt.com/codex/tasks/task_e_68998847e93c8327b9e9247640ea845b