### PR TITLE
fix: align preview card

### DIFF
--- a/src/agents/TaggerAgent.js
+++ b/src/agents/TaggerAgent.js
@@ -48,7 +48,7 @@ export default class TaggerAgent {
         const noScripts = html.replace(/<script[^>]*>[\s\S]*?<\/script>/gi, ' ')
         const noStyles  = noScripts.replace(/<style[^>]*>[\s\S]*?<\/style>/gi, ' ')
         text = noStyles.replace(/<[^>]*>/g, ' ')
-      } catch (e) {
+      } catch {
         // 忽略 fetch 失敗；維持空字串
       }
     }

--- a/src/components/UploadLinkBox.jsx
+++ b/src/components/UploadLinkBox.jsx
@@ -43,7 +43,7 @@ export default function UploadLinkBox({ onAdd }) {
           uniq.push({ tag: key, selected: s.selected !== false });
         }
         setSuggestions(uniq);
-      } catch (err) {
+      } catch {
         // 靜默失敗：清空建議避免干擾使用者
         setSuggestions([]);
         // console.error(err);

--- a/src/pages/Explore.jsx
+++ b/src/pages/Explore.jsx
@@ -209,7 +209,7 @@ function Explore() {
             </div>
           </div>
 
-          <div className="w-full md:w-5/12 mt-6 md:mt-0 md:sticky md:top-24 self-start">
+          <div className="w-full md:w-5/12 mt-6 md:mt-2 md:sticky md:top-28 self-start">
             {selectedLink
               ? <PreviewCard {...selectedLink} onTagSelect={handleTagSelect} />
               : (

--- a/src/pages/MyLinks.jsx
+++ b/src/pages/MyLinks.jsx
@@ -242,7 +242,7 @@ function MyLinks() {
             </div>
           </div>
 
-          <div className="w-full md:w-5/12 md:sticky md:top-24 self-start mt-6 md:mt-0">
+          <div className="w-full md:w-5/12 md:sticky md:top-28 self-start mt-6 md:mt-2">
             {selectedLink ? (
               <PreviewCard {...selectedLink} onTagSelect={handleTagSelect} />
             ) : (


### PR DESCRIPTION
## Summary
- adjust right column sticky offset to `md:top-28` in MyLinks and Explore
- tweak preview card margin for better alignment
- remove unused catch parameters to satisfy lint

## Testing
- `npm run lint`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_6899884e681c832780d68a530405692b