### PR TITLE
feat: unify primary button style

### DIFF
--- a/src/agents/TaggerAgent.js
+++ b/src/agents/TaggerAgent.js
@@ -48,7 +48,7 @@ export default class TaggerAgent {
         const noScripts = html.replace(/<script[^>]*>[\s\S]*?<\/script>/gi, ' ')
         const noStyles  = noScripts.replace(/<style[^>]*>[\s\S]*?<\/style>/gi, ' ')
         text = noStyles.replace(/<[^>]*>/g, ' ')
-      } catch (e) {
+      } catch {
         // 忽略 fetch 失敗；維持空字串
       }
     }

--- a/src/components/LinkCard.jsx
+++ b/src/components/LinkCard.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PrimaryButton from './PrimaryButton'
 
 function LinkCard({
   id,
@@ -76,14 +77,14 @@ function LinkCard({
       )}
 
       {/* 外部連結 */}
-      <a
+      <PrimaryButton
         href={url}
         target="_blank"
         rel="noopener noreferrer"
-        className="block text-center md:inline-block mt-2 px-4 py-2 bg-blue-500 text-white rounded"
+        className="block text-center md:inline-block mt-2"
       >
         前往連結
-      </a>
+      </PrimaryButton>
       {summary && (
         <div
           className={`pointer-events-none absolute inset-0 flex items-center justify-center bg-black bg-opacity-60 text-white text-xs p-4 rounded-lg transition-opacity duration-500 ${selected ? 'opacity-100' : 'opacity-0'}`}
@@ -96,5 +97,3 @@ function LinkCard({
 }
 
 export default LinkCard
-// LinkCard.jsx
-// 用於顯示連結卡片的組件

--- a/src/components/PreviewCard.jsx
+++ b/src/components/PreviewCard.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react'
+import PrimaryButton from './PrimaryButton'
 
 function PreviewCard({ title, description, summary, tags = [], url, onTagSelect }) {
   const [visible, setVisible] = useState(false)
@@ -35,14 +36,14 @@ function PreviewCard({ title, description, summary, tags = [], url, onTagSelect 
           </button>
         ))}
       </div>
-      <a
+      <PrimaryButton
         href={url}
         target="_blank"
         rel="noopener noreferrer"
-        className="inline-block mt-2 px-4 py-2 bg-blue-500 text-white rounded"
+        className="inline-block mt-2"
       >
         前往連結
-      </a>
+      </PrimaryButton>
     </div>
   )
 }

--- a/src/components/PrimaryButton.jsx
+++ b/src/components/PrimaryButton.jsx
@@ -1,0 +1,23 @@
+import React from 'react'
+
+function PrimaryButton({ href, className = '', children, ...props }) {
+  const baseClass = 'px-3 py-1.5 text-sm bg-blue-500 text-white rounded'
+  const combinedClass = `${baseClass} ${className}`.trim()
+
+  if (href) {
+    return (
+      <a href={href} className={combinedClass} {...props}>
+        {children}
+      </a>
+    )
+  }
+
+  return (
+    <button className={combinedClass} {...props}>
+      {children}
+    </button>
+  )
+}
+
+export default PrimaryButton
+

--- a/src/components/UploadLinkBox.jsx
+++ b/src/components/UploadLinkBox.jsx
@@ -43,7 +43,7 @@ export default function UploadLinkBox({ onAdd }) {
           uniq.push({ tag: key, selected: s.selected !== false });
         }
         setSuggestions(uniq);
-      } catch (err) {
+      } catch {
         // 靜默失敗：清空建議避免干擾使用者
         setSuggestions([]);
         // console.error(err);


### PR DESCRIPTION
## Summary
- add reusable `PrimaryButton` component for consistent sizing
- apply `PrimaryButton` in `LinkCard` and `PreviewCard`
- remove unused variables flagged by ESLint

## Testing
- `npm run lint`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_6899885e5324832783c220da467d2ec8