### PR TITLE
feat: add paste link shortcut button

### DIFF
--- a/src/agents/TaggerAgent.js
+++ b/src/agents/TaggerAgent.js
@@ -48,7 +48,7 @@ export default class TaggerAgent {
         const noScripts = html.replace(/<script[^>]*>[\s\S]*?<\/script>/gi, ' ')
         const noStyles  = noScripts.replace(/<style[^>]*>[\s\S]*?<\/style>/gi, ' ')
         text = noStyles.replace(/<[^>]*>/g, ' ')
-      } catch (e) {
+      } catch {
         // 忽略 fetch 失敗；維持空字串
       }
     }

--- a/src/components/UploadLinkBox.jsx
+++ b/src/components/UploadLinkBox.jsx
@@ -1,6 +1,6 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, forwardRef } from 'react';
 
-export default function UploadLinkBox({ onAdd }) {
+const UploadLinkBox = forwardRef(function UploadLinkBox({ onAdd }, ref) {
   const [link, setLink] = useState('');
   const [title, setTitle] = useState('');
   const [tags, setTags] = useState(''); // 手動輸入（以逗號分隔）
@@ -43,7 +43,7 @@ export default function UploadLinkBox({ onAdd }) {
           uniq.push({ tag: key, selected: s.selected !== false });
         }
         setSuggestions(uniq);
-      } catch (err) {
+      } catch {
         // 靜默失敗：清空建議避免干擾使用者
         setSuggestions([]);
         // console.error(err);
@@ -94,6 +94,7 @@ export default function UploadLinkBox({ onAdd }) {
   return (
     <div className="bg-white p-3 md:p-4 rounded shadow space-y-3 w-full max-w-md text-sm md:text-base">
       <input
+        ref={ref}
         className="w-full bg-white border border-gray-300 rounded-md px-4 py-2 text-black focus:outline-none focus:ring-2 focus:ring-blue-500"
         placeholder="貼上公開分享連結"
         value={link}
@@ -163,5 +164,7 @@ export default function UploadLinkBox({ onAdd }) {
       </button>
     </div>
   );
-}
+});
+
+export default UploadLinkBox;
 

--- a/src/pages/Explore.jsx
+++ b/src/pages/Explore.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from 'react'
+import React, { useState, useEffect, useMemo, useRef } from 'react'
 import Header from '../components/Header.jsx'
 import UploadLinkBox from '../components/UploadLinkBox.jsx'
 import LinkCard from '../components/LinkCard.jsx'
@@ -54,6 +54,7 @@ function Explore() {
   const [selectedLink, setSelectedLink] = useState(null)
   const [userId, setUserId] = useState('')
   const [selectedTags, setSelectedTags] = useState([])
+  const uploadRef = useRef(null)
 
   const availableTags = useMemo(
     () => [...new Set(links.flatMap(l => l.tags))],
@@ -180,7 +181,7 @@ function Explore() {
 
         <div className="flex flex-col md:flex-row gap-6">
           <div className="w-full md:w-7/12 space-y-6">
-            <UploadLinkBox onAdd={handleAdd} />
+            <UploadLinkBox onAdd={handleAdd} ref={uploadRef} />
 
             <div className="flex items-center justify-between">
               <span className="text-sm text-gray-500">已選 {selectedTags.length}</span>
@@ -213,8 +214,15 @@ function Explore() {
             {selectedLink
               ? <PreviewCard {...selectedLink} onTagSelect={handleTagSelect} />
               : (
-                <div className="bg-gray-100 text-gray-500 flex items-center justify-center h-full p-6 rounded">
-                  請選擇一個連結以預覽
+                <div className="bg-gray-100 text-gray-500 flex flex-col items-center justify-center h-full p-6 rounded">
+                  <p className="mb-2">請選擇一個連結以預覽</p>
+                  <button
+                    type="button"
+                    className="text-sm text-blue-500 hover:underline"
+                    onClick={() => uploadRef.current?.focus()}
+                  >
+                    貼上連結
+                  </button>
                 </div>
               )}
           </div>

--- a/src/pages/MyLinks.jsx
+++ b/src/pages/MyLinks.jsx
@@ -52,6 +52,7 @@ function MyLinks() {
   const [userId, setUserId] = useState('')
   const [selectedTags, setSelectedTags] = useState([])
   const listRef = useRef(null)
+  const uploadRef = useRef(null)
 
   const availableTags = useMemo(
     () => [...new Set(links.flatMap(l => l.tags))],
@@ -208,7 +209,7 @@ function MyLinks() {
 
         <div className="flex flex-col md:flex-row gap-6">
           <div className="w-full md:w-7/12 space-y-6">
-            <UploadLinkBox onAdd={handleAdd} />
+            <UploadLinkBox onAdd={handleAdd} ref={uploadRef} />
 
             <div className="space-y-4">
               <div className="flex items-center justify-between">
@@ -246,8 +247,15 @@ function MyLinks() {
             {selectedLink ? (
               <PreviewCard {...selectedLink} onTagSelect={handleTagSelect} />
             ) : (
-              <div className="bg-gray-100 text-gray-500 flex items-center justify-center h-full p-6 rounded">
-                請選擇一個連結以預覽
+              <div className="bg-gray-100 text-gray-500 flex flex-col items-center justify-center h-full p-6 rounded">
+                <p className="mb-2">請選擇一個連結以預覽</p>
+                <button
+                  type="button"
+                  className="text-sm text-blue-500 hover:underline"
+                  onClick={() => uploadRef.current?.focus()}
+                >
+                  貼上連結
+                </button>
               </div>
             )}
           </div>


### PR DESCRIPTION
## Summary
- add "貼上連結" button in preview empty state to focus UploadLinkBox
- allow focusing UploadLinkBox input via forwarded ref
- clean up unused variables in agents to satisfy lint

## Testing
- `npm run lint`
- `npm test` *(fails: expected undefined to deeply equal [...], expected '' to contain 'AI')*


------
https://chatgpt.com/codex/tasks/task_e_68998864bd408327bd99807115123adc