### PR TITLE
feat: add stats toggle on MyLinks

### DIFF
--- a/src/agents/TaggerAgent.js
+++ b/src/agents/TaggerAgent.js
@@ -48,7 +48,7 @@ export default class TaggerAgent {
         const noScripts = html.replace(/<script[^>]*>[\s\S]*?<\/script>/gi, ' ')
         const noStyles  = noScripts.replace(/<style[^>]*>[\s\S]*?<\/style>/gi, ' ')
         text = noStyles.replace(/<[^>]*>/g, ' ')
-      } catch (e) {
+      } catch {
         // 忽略 fetch 失敗；維持空字串
       }
     }

--- a/src/components/UploadLinkBox.jsx
+++ b/src/components/UploadLinkBox.jsx
@@ -43,7 +43,7 @@ export default function UploadLinkBox({ onAdd }) {
           uniq.push({ tag: key, selected: s.selected !== false });
         }
         setSuggestions(uniq);
-      } catch (err) {
+      } catch {
         // 靜默失敗：清空建議避免干擾使用者
         setSuggestions([]);
         // console.error(err);

--- a/src/pages/MyLinks.jsx
+++ b/src/pages/MyLinks.jsx
@@ -51,6 +51,9 @@ function MyLinks() {
   const [selectedLink, setSelectedLink] = useState(null)
   const [userId, setUserId] = useState('')
   const [selectedTags, setSelectedTags] = useState([])
+  const [showStats, setShowStats] = useState(() =>
+    localStorage.getItem('showStats') !== '0'
+  )
   const listRef = useRef(null)
 
   const availableTags = useMemo(
@@ -176,6 +179,14 @@ function MyLinks() {
     )
   }
 
+  function handleToggleStats() {
+    setShowStats(prev => {
+      const next = !prev
+      localStorage.setItem('showStats', next ? '1' : '0')
+      return next
+    })
+  }
+
   function renderListItem(link) {
     return (
       <LinkCard
@@ -199,10 +210,20 @@ function MyLinks() {
       <div className="container mx-auto px-4 space-y-6">
         <div className="flex justify-between items-start">
           <Header />
-          {!IS_PUBLIC && LazyStatsPanel && (
-            <React.Suspense fallback={null}>
-              <LazyStatsPanel links={links} compact />
-            </React.Suspense>
+          {!IS_PUBLIC && (
+            <div className="flex items-center gap-4">
+              {showStats && LazyStatsPanel && (
+                <React.Suspense fallback={null}>
+                  <LazyStatsPanel links={links} compact />
+                </React.Suspense>
+              )}
+              <button
+                className="text-sm text-blue-500 hover:underline"
+                onClick={handleToggleStats}
+              >
+                {showStats ? '隱藏統計' : '顯示統計'}
+              </button>
+            </div>
           )}
         </div>
 


### PR DESCRIPTION
## Summary
- add "顯示統計" toggle button on MyLinks with localStorage persistence
- clean up unused variables to satisfy lint

## Testing
- `npm run lint`
- `npm run dev`


------
https://chatgpt.com/codex/tasks/task_e_6899886dc7c083278c3701652462382c