### PR TITLE
feat: add tone theme emotion defaults

### DIFF
--- a/src/pages/Explore.jsx
+++ b/src/pages/Explore.jsx
@@ -43,6 +43,9 @@ function normalizeItem(data, userId) {
     platform: data.platform || 'Unknown',
     language: data.language || 'unknown',
     description: data.description || '',
+    tone: data.tone ?? null,
+    theme: data.theme ?? null,
+    emotion: data.emotion ?? null,
     createdBy: data.createdBy || userId,
     createdAt: data.createdAt || new Date().toISOString(),
   }
@@ -106,6 +109,9 @@ function Explore() {
       const normalized = await Promise.all(
         items.map(async (item) => {
           const updated = normalizeItem(item, userId)
+          if (item.tone === undefined) { updated.tone = null; changed = true }
+          if (item.theme === undefined) { updated.theme = null; changed = true }
+          if (item.emotion === undefined) { updated.emotion = null; changed = true }
           if (!item.createdAt) changed = true
           if (!updated.summary) {
             try {

--- a/src/pages/MyLinks.jsx
+++ b/src/pages/MyLinks.jsx
@@ -36,6 +36,9 @@ function normalizeItem(data, userId) {
     platform: data.platform || 'Unknown',
     language: data.language || 'unknown',
     description: data.description || '',
+    tone: data.tone ?? null,
+    theme: data.theme ?? null,
+    emotion: data.emotion ?? null,
     createdBy: data.createdBy || userId,
     createdAt: data.createdAt || new Date().toISOString(),
   }
@@ -117,6 +120,9 @@ function MyLinks() {
       const normalized = await Promise.all(
         items.map(async (item) => {
           const updated = normalizeItem(item, userId)
+          if (item.tone === undefined) { updated.tone = null; changed = true }
+          if (item.theme === undefined) { updated.theme = null; changed = true }
+          if (item.emotion === undefined) { updated.emotion = null; changed = true }
           if (!item.createdAt) changed = true
           if (!updated.summary) {
             try {


### PR DESCRIPTION
## Summary
- add tone, theme, and emotion fields to stored links with null fallbacks
- ensure item processing backfills missing tone/theme/emotion and persists to storage

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899ca3819588327b3b09e5f4f49a4ec