### PR TITLE
feat: add tone theme emotion selectors

### DIFF
--- a/src/components/UploadLinkBox.jsx
+++ b/src/components/UploadLinkBox.jsx
@@ -1,10 +1,17 @@
 import { useEffect, useState, forwardRef } from 'react';
 
+const TONE_OPTIONS = ['Neutral', 'Friendly', 'Serious'];
+const THEME_OPTIONS = ['AI', 'Education', 'Art'];
+const EMOTION_OPTIONS = ['Positive', 'Neutral', 'Negative'];
+
 const UploadLinkBox = forwardRef(function UploadLinkBox({ onAdd }, ref) {
   const [link, setLink] = useState('');
   const [title, setTitle] = useState('');
   const [tags, setTags] = useState(''); // 手動輸入（以逗號分隔）
   const [suggestions, setSuggestions] = useState([]); // [{ tag, selected }]
+  const [tone, setTone] = useState(null);
+  const [theme, setTheme] = useState(null);
+  const [emotion, setEmotion] = useState(null);
 
   useEffect(() => {
     const url = link.trim();
@@ -81,6 +88,9 @@ const UploadLinkBox = forwardRef(function UploadLinkBox({ onAdd }, ref) {
       url,
       title: title.trim(),
       tags: merged,
+      tone,
+      theme,
+      emotion,
     });
 
     // 重置表單
@@ -88,6 +98,9 @@ const UploadLinkBox = forwardRef(function UploadLinkBox({ onAdd }, ref) {
     setTitle('');
     setTags('');
     setSuggestions([]);
+    setTone(null);
+    setTheme(null);
+    setEmotion(null);
   };
 
   return (
@@ -111,6 +124,66 @@ const UploadLinkBox = forwardRef(function UploadLinkBox({ onAdd }, ref) {
         value={tags}
         onChange={(e) => setTags(e.target.value)}
       />
+
+      <div>
+        <span className="text-sm text-gray-500">Tone</span>
+        <div className="flex flex-wrap gap-2 mt-1">
+          {TONE_OPTIONS.map((opt) => (
+            <button
+              key={opt}
+              type="button"
+              onClick={() => setTone(tone === opt ? null : opt)}
+              className={`px-2 py-1 rounded-full border text-sm ${
+                tone === opt
+                  ? 'bg-blue-500 text-white border-blue-500'
+                  : 'bg-gray-200 text-gray-700 border-gray-200'
+              }`}
+            >
+              {opt}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div>
+        <span className="text-sm text-gray-500">Theme</span>
+        <div className="flex flex-wrap gap-2 mt-1">
+          {THEME_OPTIONS.map((opt) => (
+            <button
+              key={opt}
+              type="button"
+              onClick={() => setTheme(theme === opt ? null : opt)}
+              className={`px-2 py-1 rounded-full border text-sm ${
+                theme === opt
+                  ? 'bg-blue-500 text-white border-blue-500'
+                  : 'bg-gray-200 text-gray-700 border-gray-200'
+              }`}
+            >
+              {opt}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div>
+        <span className="text-sm text-gray-500">Emotion</span>
+        <div className="flex flex-wrap gap-2 mt-1">
+          {EMOTION_OPTIONS.map((opt) => (
+            <button
+              key={opt}
+              type="button"
+              onClick={() => setEmotion(emotion === opt ? null : opt)}
+              className={`px-2 py-1 rounded-full border text-sm ${
+                emotion === opt
+                  ? 'bg-blue-500 text-white border-blue-500'
+                  : 'bg-gray-200 text-gray-700 border-gray-200'
+              }`}
+            >
+              {opt}
+            </button>
+          ))}
+        </div>
+      </div>
 
       {suggestions.length > 0 && (
         <>

--- a/src/components/__tests__/UploadLinkBox.test.jsx
+++ b/src/components/__tests__/UploadLinkBox.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
 import UploadLinkBox from '../UploadLinkBox.jsx'
 import { vi } from 'vitest'
 
@@ -27,7 +27,7 @@ describe('UploadLinkBox tag suggestions', () => {
     expect(suggestionBox).toBeInTheDocument()
 
     // 預設為選取（藍色）
-    const aiButton = screen.getByText('AI')
+    const aiButton = within(suggestionBox).getByText('AI')
     expect(aiButton).toHaveClass('bg-blue-500')
 
     // 點一下切換為未選取（灰色）


### PR DESCRIPTION
## Summary
- add tone, theme, and emotion selectors to UploadLinkBox
- include selected tone, theme, emotion when adding links
- adjust UploadLinkBox tests to account for new selectors

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899ca3b7c788327ae15eb61fe8ff9c9