### PR TITLE
feat: add classification filter

### DIFF
--- a/src/components/ClassifyFilter.jsx
+++ b/src/components/ClassifyFilter.jsx
@@ -1,0 +1,59 @@
+import React from 'react'
+
+function ClassifyFilter({ toneOptions = [], themeOptions = [], emotionOptions = [], selectedTone, selectedTheme, selectedEmotion, onChange }) {
+  const handleSelect = (type, value) => {
+    if (!onChange) return
+    const next = { tone: selectedTone, theme: selectedTheme, emotion: selectedEmotion }
+    next[type] = next[type] === value ? null : value
+    onChange(next)
+  }
+
+  const handleClear = (type) => {
+    if (!onChange) return
+    const next = { tone: selectedTone, theme: selectedTheme, emotion: selectedEmotion }
+    next[type] = null
+    onChange(next)
+  }
+
+  const renderGroup = (label, options, selectedValue, type) => (
+    <div className="mb-4">
+      <div className="flex items-center gap-2 mb-1">
+        <span>{label}</span>
+        <button
+          type="button"
+          onClick={() => handleClear(type)}
+          className={`text-sm ${selectedValue ? 'text-blue-500 hover:underline' : 'text-gray-300 cursor-not-allowed'}`}
+          disabled={!selectedValue}
+        >
+          清除
+        </button>
+      </div>
+      <div className="flex flex-wrap gap-2 mt-1">
+        {options.map(opt => {
+          const active = selectedValue === opt
+          return (
+            <button
+              key={opt}
+              type="button"
+              onClick={() => handleSelect(type, opt)}
+              className={`px-2 py-1 rounded text-sm ${active ? 'bg-blue-500 text-white' : 'bg-blue-100 text-blue-800'}`}
+            >
+              {opt}
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
+
+  return (
+    <div>
+      {renderGroup('語氣', toneOptions, selectedTone, 'tone')}
+      {renderGroup('主題', themeOptions, selectedTheme, 'theme')}
+      {renderGroup('情緒', emotionOptions, selectedEmotion, 'emotion')}
+    </div>
+  )
+}
+
+export default ClassifyFilter
+

--- a/src/pages/Explore.jsx
+++ b/src/pages/Explore.jsx
@@ -5,6 +5,7 @@ import LinkCard from '../components/LinkCard.jsx'
 import PreviewCard from '../components/PreviewCard.jsx'
 import TagFilter from '../components/TagFilter.jsx'
 import SummarizerAgent from '../agents/SummarizerAgent.js'
+import ClassifyFilter from '../components/ClassifyFilter.jsx'
 
 // === 可見性旗標：公開視圖不顯示統計（之後要改可從環境變數或設定注入）===
 const IS_PUBLIC = true
@@ -55,12 +56,16 @@ function Explore() {
   const [selectedLink, setSelectedLink] = useState(null)
   const [userId, setUserId] = useState('')
   const [selectedTags, setSelectedTags] = useState([])
+  const [classify, setClassify] = useState({ tone: null, theme: null, emotion: null })
   const uploadRef = useRef(null)
 
   const availableTags = useMemo(
     () => Object.keys(tagCounts),
     [tagCounts]
   )
+  const toneOptions = useMemo(() => Array.from(new Set(links.map(l => l.tone).filter(Boolean))), [links])
+  const themeOptions = useMemo(() => Array.from(new Set(links.map(l => l.theme).filter(Boolean))), [links])
+  const emotionOptions = useMemo(() => Array.from(new Set(links.map(l => l.emotion).filter(Boolean))), [links])
 
   const buildTagCounts = items => {
     const counts = {}
@@ -193,9 +198,14 @@ function Explore() {
   }
 
   const filteredLinks = useMemo(() => {
-    if (selectedTags.length === 0) return links
-    return links.filter(link => selectedTags.every(tag => link.tags.includes(tag)))
-  }, [links, selectedTags])
+    return links.filter(link => {
+      const tagMatch = selectedTags.every(tag => link.tags.includes(tag))
+      const toneMatch = !classify.tone || link.tone === classify.tone
+      const themeMatch = !classify.theme || link.theme === classify.theme
+      const emotionMatch = !classify.emotion || link.emotion === classify.emotion
+      return tagMatch && toneMatch && themeMatch && emotionMatch
+    })
+  }, [links, selectedTags, classify])
 
   return (
     <div className="min-h-screen bg-gray-50 flex justify-center items-start px-6 py-8 overflow-x-hidden">
@@ -214,6 +224,16 @@ function Explore() {
             <UploadLinkBox onAdd={handleAdd} ref={uploadRef} />
 
             <div className="mt-2">
+              <ClassifyFilter
+                toneOptions={toneOptions}
+                themeOptions={themeOptions}
+                emotionOptions={emotionOptions}
+                selectedTone={classify.tone}
+                selectedTheme={classify.theme}
+                selectedEmotion={classify.emotion}
+                onChange={setClassify}
+              />
+
               <TagFilter
                 tags={availableTags}
                 selected={selectedTags}

--- a/src/pages/MyLinks.jsx
+++ b/src/pages/MyLinks.jsx
@@ -4,6 +4,7 @@ import UploadLinkBox from '../components/UploadLinkBox.jsx'
 import LinkCard from '../components/LinkCard.jsx'
 import PreviewCard from '../components/PreviewCard.jsx'
 import TagFilter from '../components/TagFilter.jsx'
+import ClassifyFilter from '../components/ClassifyFilter.jsx'
 import SummarizerAgent from '../agents/SummarizerAgent.js'
 import Sortable from 'sortablejs'
 
@@ -48,11 +49,15 @@ function MyLinks() {
   const [selectedLink, setSelectedLink] = useState(null)
   const [userId, setUserId] = useState('')
   const [selectedTags, setSelectedTags] = useState([])
+  const [classify, setClassify] = useState({ tone: null, theme: null, emotion: null })
   const [showStats, setShowStats] = useState(() => localStorage.getItem('showStats') !== '0')
   const listRef = useRef(null)
   const uploadRef = useRef(null)
 
   const availableTags = useMemo(() => Object.keys(tagCounts), [tagCounts])
+  const toneOptions = useMemo(() => Array.from(new Set(links.map(l => l.tone).filter(Boolean))), [links])
+  const themeOptions = useMemo(() => Array.from(new Set(links.map(l => l.theme).filter(Boolean))), [links])
+  const emotionOptions = useMemo(() => Array.from(new Set(links.map(l => l.emotion).filter(Boolean))), [links])
 
   const buildTagCounts = (items) => {
     const counts = {}
@@ -218,9 +223,14 @@ function MyLinks() {
   }
 
   const filteredLinks = useMemo(() => {
-    if (selectedTags.length === 0) return links
-    return links.filter(link => selectedTags.every(tag => link.tags.includes(tag)))
-  }, [links, selectedTags])
+    return links.filter(link => {
+      const tagMatch = selectedTags.every(tag => link.tags.includes(tag))
+      const toneMatch = !classify.tone || link.tone === classify.tone
+      const themeMatch = !classify.theme || link.theme === classify.theme
+      const emotionMatch = !classify.emotion || link.emotion === classify.emotion
+      return tagMatch && toneMatch && themeMatch && emotionMatch
+    })
+  }, [links, selectedTags, classify])
 
   return (
     <div className="min-h-screen bg-gray-50 flex justify-center items-start px-6 py-8 overflow-x-hidden">
@@ -250,6 +260,16 @@ function MyLinks() {
             <UploadLinkBox onAdd={handleAdd} ref={uploadRef} />
 
             <div className="mt-2">
+              <ClassifyFilter
+                toneOptions={toneOptions}
+                themeOptions={themeOptions}
+                emotionOptions={emotionOptions}
+                selectedTone={classify.tone}
+                selectedTheme={classify.theme}
+                selectedEmotion={classify.emotion}
+                onChange={setClassify}
+              />
+
               <TagFilter
                 tags={availableTags}
                 selected={selectedTags}


### PR DESCRIPTION
## Summary
- add ClassifyFilter component with tone, theme and emotion chips
- integrate classification filters into MyLinks and Explore pages
- filter links using tags and classification criteria

## Testing
- `npm run lint`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_6899ca3cf128832795b7b9019de60a99