### PR TITLE
feat: persist tone/theme/emotion classifications

### DIFF
--- a/src/pages/Explore.jsx
+++ b/src/pages/Explore.jsx
@@ -40,6 +40,9 @@ function normalizeItem(data, userId) {
     url: data.url || data.link,
     title: data.title || '未命名',
     tags: Array.isArray(data.tags) ? data.tags : [],
+    tone: data.tone || '',
+    theme: data.theme || '',
+    emotion: data.emotion || '',
     platform: data.platform || 'Unknown',
     language: data.language || 'unknown',
     description: data.description || '',
@@ -67,6 +70,8 @@ function Explore() {
     for (const l of items) if (Array.isArray(l.tags)) for (const t of l.tags) counts[t] = (counts[t] || 0) + 1
     return counts
   }
+
+  // TODO: add tone/theme/emotion counts when classification is enabled
 
   const increaseTagCounts = tags => {
     setTagCounts(prev => {
@@ -141,6 +146,7 @@ function Explore() {
 
   // 新增連結
   async function handleAdd(data) {
+    // tone/theme/emotion are passed through normalizeItem and persisted
     const base = normalizeItem(data, userId)
     let summary = ''
     try {

--- a/src/pages/MyLinks.jsx
+++ b/src/pages/MyLinks.jsx
@@ -33,6 +33,9 @@ function normalizeItem(data, userId) {
     url: data.url || data.link,
     title: data.title || '未命名',
     tags: Array.isArray(data.tags) ? data.tags : [],
+    tone: data.tone || '',
+    theme: data.theme || '',
+    emotion: data.emotion || '',
     platform: data.platform || 'Unknown',
     language: data.language || 'unknown',
     description: data.description || '',
@@ -59,6 +62,8 @@ function MyLinks() {
     for (const l of items) if (Array.isArray(l.tags)) for (const t of l.tags) counts[t] = (counts[t] || 0) + 1
     return counts
   }
+
+  // TODO: classification counts (tone/theme/emotion) can be added here later
 
   const increaseTagCounts = (tags) => {
     setTagCounts(prev => {
@@ -155,6 +160,7 @@ function MyLinks() {
 
   // 新增連結
   async function handleAdd(data) {
+    // tone/theme/emotion are passed through normalizeItem and persisted
     const base = normalizeItem(data, userId)
     let summary = ''
     try {


### PR DESCRIPTION
## Summary
- persist tone, theme and emotion fields via `normalizeItem`
- ensure `handleAdd` saves classification fields to localStorage
- leave TODO to extend tag count helpers for classification counts

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899ca3fc5c4832786692e5f210339cf