### PR TITLE
feat: add classification filters and tests

### DIFF
--- a/src/components/UploadLinkBox.jsx
+++ b/src/components/UploadLinkBox.jsx
@@ -5,6 +5,15 @@ const UploadLinkBox = forwardRef(function UploadLinkBox({ onAdd }, ref) {
   const [title, setTitle] = useState('');
   const [tags, setTags] = useState(''); // 手動輸入（以逗號分隔）
   const [suggestions, setSuggestions] = useState([]); // [{ tag, selected }]
+  const [classify, setClassify] = useState({ tone: null, theme: null, emotion: null });
+
+  const tones = ['理性', '感性'];
+  const themes = ['科技', '生活'];
+  const emotions = ['開心', '難過'];
+
+  const toggleClassify = (field, value) => {
+    setClassify((prev) => ({ ...prev, [field]: prev[field] === value ? null : value }));
+  };
 
   useEffect(() => {
     const url = link.trim();
@@ -81,6 +90,7 @@ const UploadLinkBox = forwardRef(function UploadLinkBox({ onAdd }, ref) {
       url,
       title: title.trim(),
       tags: merged,
+      classify,
     });
 
     // 重置表單
@@ -88,6 +98,7 @@ const UploadLinkBox = forwardRef(function UploadLinkBox({ onAdd }, ref) {
     setTitle('');
     setTags('');
     setSuggestions([]);
+    setClassify({ tone: null, theme: null, emotion: null });
   };
 
   return (
@@ -111,6 +122,52 @@ const UploadLinkBox = forwardRef(function UploadLinkBox({ onAdd }, ref) {
         value={tags}
         onChange={(e) => setTags(e.target.value)}
       />
+
+      {/* 分類選擇 chips */}
+      <div className="space-y-2">
+        <div className="flex flex-wrap gap-2" data-testid="tone-chips">
+          {tones.map((t) => (
+            <button
+              key={t}
+              type="button"
+              className={`px-2 py-1 rounded-full border text-sm ${
+                classify.tone === t ? 'bg-green-500 text-white border-green-500' : 'bg-gray-200 text-gray-700 border-gray-200'
+              }`}
+              onClick={() => toggleClassify('tone', t)}
+            >
+              {t}
+            </button>
+          ))}
+        </div>
+        <div className="flex flex-wrap gap-2" data-testid="theme-chips">
+          {themes.map((t) => (
+            <button
+              key={t}
+              type="button"
+              className={`px-2 py-1 rounded-full border text-sm ${
+                classify.theme === t ? 'bg-green-500 text-white border-green-500' : 'bg-gray-200 text-gray-700 border-gray-200'
+              }`}
+              onClick={() => toggleClassify('theme', t)}
+            >
+              {t}
+            </button>
+          ))}
+        </div>
+        <div className="flex flex-wrap gap-2" data-testid="emotion-chips">
+          {emotions.map((t) => (
+            <button
+              key={t}
+              type="button"
+              className={`px-2 py-1 rounded-full border text-sm ${
+                classify.emotion === t ? 'bg-green-500 text-white border-green-500' : 'bg-gray-200 text-gray-700 border-gray-200'
+              }`}
+              onClick={() => toggleClassify('emotion', t)}
+            >
+              {t}
+            </button>
+          ))}
+        </div>
+      </div>
 
       {suggestions.length > 0 && (
         <>

--- a/src/components/__tests__/UploadLinkBox.test.jsx
+++ b/src/components/__tests__/UploadLinkBox.test.jsx
@@ -37,5 +37,38 @@ describe('UploadLinkBox tag suggestions', () => {
       expect(aiButton).toHaveClass('bg-gray-200')
     })
   })
+
+  test('selecting and clearing classification chips sends classify field', () => {
+    const onAdd = vi.fn()
+    render(<UploadLinkBox onAdd={onAdd} />)
+
+    fireEvent.change(
+      screen.getByPlaceholderText('貼上公開分享連結'),
+      { target: { value: 'http://example.com' } }
+    )
+
+    // select tone/theme/emotion
+    fireEvent.click(screen.getByText('理性'))
+    fireEvent.click(screen.getByText('科技'))
+    fireEvent.click(screen.getByText('開心'))
+
+    fireEvent.click(screen.getByText('新增'))
+    expect(onAdd).toHaveBeenLastCalledWith(
+      expect.objectContaining({ classify: { tone: '理性', theme: '科技', emotion: '開心' } })
+    )
+
+    // second submission with tone cleared
+    fireEvent.change(
+      screen.getByPlaceholderText('貼上公開分享連結'),
+      { target: { value: 'http://example2.com' } }
+    )
+    const toneChip = screen.getByText('理性')
+    fireEvent.click(toneChip) // select
+    fireEvent.click(toneChip) // clear
+    fireEvent.click(screen.getByText('新增'))
+    expect(onAdd).toHaveBeenLastCalledWith(
+      expect.objectContaining({ classify: { tone: null, theme: null, emotion: null } })
+    )
+  })
 })
 

--- a/src/pages/__tests__/MyLinks.test.jsx
+++ b/src/pages/__tests__/MyLinks.test.jsx
@@ -1,0 +1,43 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import MyLinks from '../MyLinks.jsx'
+import normalizeItem from '../../utils/normalizeItem.js'
+
+describe('MyLinks filtering', () => {
+  test('filters by tone and tags with AND behaviour', () => {
+    const user = 'user'
+    const links = [
+      normalizeItem({ url: 'http://a', title: 'A', tags: ['t1'], classify: { tone: '理性' } }, user),
+      normalizeItem({ url: 'http://b', title: 'B', tags: ['t1'], classify: { tone: '感性' } }, user),
+      normalizeItem({ url: 'http://c', title: 'C', tags: ['t2'], classify: { tone: '理性' } }, user),
+    ]
+
+    render(
+      <MemoryRouter>
+        <MyLinks initialLinks={links} initialClassify={{ tone: '理性', theme: null, emotion: null }} />
+      </MemoryRouter>
+    )
+
+    // only tone "理性" links render
+    expect(screen.getByText('A')).toBeInTheDocument()
+    expect(screen.getByText('C')).toBeInTheDocument()
+    expect(screen.queryByText('B')).toBeNull()
+
+    // apply tag filter t2 => AND filter
+    fireEvent.click(screen.getAllByText('#t2')[0])
+    expect(screen.queryByText('A')).toBeNull()
+    expect(screen.getByText('C')).toBeInTheDocument()
+  })
+})
+
+describe('normalizeItem', () => {
+  test('defaults classify fields to null', () => {
+    const item = normalizeItem({ url: 'http://x' }, 'user')
+    expect(item.classify).toEqual({ tone: null, theme: null, emotion: null })
+  })
+
+  test('retains provided classify fields', () => {
+    const item = normalizeItem({ url: 'http://x', classify: { tone: '理性' } }, 'user')
+    expect(item.classify).toEqual({ tone: '理性', theme: null, emotion: null })
+  })
+})

--- a/src/utils/normalizeItem.js
+++ b/src/utils/normalizeItem.js
@@ -1,0 +1,23 @@
+export function generateItemId() {
+  if (crypto?.randomUUID) return crypto.randomUUID()
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`
+}
+
+export default function normalizeItem(data, userId) {
+  return {
+    id: data.id || generateItemId(),
+    url: data.url || data.link,
+    title: data.title || '未命名',
+    tags: Array.isArray(data.tags) ? data.tags : [],
+    classify: {
+      tone: data.classify?.tone ?? null,
+      theme: data.classify?.theme ?? null,
+      emotion: data.classify?.emotion ?? null,
+    },
+    platform: data.platform || 'Unknown',
+    language: data.language || 'unknown',
+    description: data.description || '',
+    createdBy: data.createdBy || userId,
+    createdAt: data.createdAt || new Date().toISOString(),
+  }
+}


### PR DESCRIPTION
## Summary
- support tone/theme/emotion chips in UploadLinkBox
- allow MyLinks to filter links by tone and tags
- cover normalizeItem defaults and classification behaviour with tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899ca4150548327965c8e598ba5bb52