### PR TITLE
fix: allow link alias for url in TaggerAgent

### DIFF
--- a/src/agents/TaggerAgent.js
+++ b/src/agents/TaggerAgent.js
@@ -26,16 +26,18 @@ export default class TaggerAgent {
   }
 
   /**
-   * 相容舊版：run('pure text')；新版：run({ title, description, summary, url, content, limit })
+   * 相容舊版：run('pure text')；新版：run({ title, description, summary, url, link, content, limit })
+   * `link` 為 `url` 的別名
    * 回傳：{ tags: string[] }
    */
   async run(input = {}) {
     // --- 參數歸一化 ---
-    let title = '', description = '', summary = '', url = '', content = '', limit
+    let title = '', description = '', summary = '', url = '', link = '', content = '', limit
     if (typeof input === 'string') {
       content = input
     } else {
-      ({ title = '', description = '', summary = '', url = '', content = '', limit } = input)
+      ({ title = '', description = '', summary = '', url = '', link = '', content = '', limit } = input)
+      url = url || link
     }
     const maxTags = Math.max(3, Math.min(Number(limit) || this.options.defaultLimit, 12))
 

--- a/src/agents/__tests__/TaggerAgent.test.js
+++ b/src/agents/__tests__/TaggerAgent.test.js
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 import TaggerAgent from '../TaggerAgent.js'
 
 describe('TaggerAgent', () => {
@@ -30,6 +30,18 @@ describe('TaggerAgent', () => {
     const agent = new TaggerAgent()
     const { tags } = await agent.run({ content: 'react react prompt gpt youtube ai tool', limit: 3 })
     expect(tags.length).toBeLessThanOrEqual(3)
+  })
+
+  test('accepts link as alias for url when fetching content', async () => {
+    const html = '<div>GPT tool on YouTube</div>'
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = vi.fn().mockResolvedValue({ text: () => Promise.resolve(html) })
+    const agent = new TaggerAgent({ allowFetch: true })
+    const { tags } = await agent.run({ link: 'http://example.com/mock' })
+    const lower = new Set(tags.map(t => t.toLowerCase()))
+    expect(lower.has('gpt')).toBe(true)
+    expect(lower.has('youtube')).toBe(true)
+    globalThis.fetch = originalFetch
   })
 })
 


### PR DESCRIPTION
## Summary
- support `link` as alias for `url` in TaggerAgent
- add test verifying tag generation when fetching via link

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899ca447e4083279572149162d0bd98