### PR TITLE
feat: add classification filters

### DIFF
--- a/src/components/ClassificationFilter.jsx
+++ b/src/components/ClassificationFilter.jsx
@@ -1,0 +1,43 @@
+import React from 'react'
+
+function ClassificationFilter({
+  platforms = [],
+  languages = [],
+  selectedPlatform = '',
+  selectedLanguage = '',
+  onPlatformChange,
+  onLanguageChange,
+}) {
+  return (
+    <div className="flex gap-4 mb-2">
+      <select
+        value={selectedPlatform}
+        onChange={(e) => onPlatformChange?.(e.target.value)}
+        className="border rounded p-1"
+        data-testid="platform-filter"
+      >
+        <option value="">全部平台</option>
+        {platforms.map((p) => (
+          <option key={p} value={p}>
+            {p}
+          </option>
+        ))}
+      </select>
+      <select
+        value={selectedLanguage}
+        onChange={(e) => onLanguageChange?.(e.target.value)}
+        className="border rounded p-1"
+        data-testid="language-filter"
+      >
+        <option value="">全部語言</option>
+        {languages.map((l) => (
+          <option key={l} value={l}>
+            {l}
+          </option>
+        ))}
+      </select>
+    </div>
+  )
+}
+
+export default ClassificationFilter

--- a/src/components/__tests__/ClassificationFilter.test.jsx
+++ b/src/components/__tests__/ClassificationFilter.test.jsx
@@ -1,0 +1,30 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import React from 'react'
+import ClassificationFilter from '../ClassificationFilter.jsx'
+
+function Wrapper() {
+  const [platform, setPlatform] = React.useState('')
+  const [language, setLanguage] = React.useState('')
+  return (
+    <>
+      <span data-testid="vals">{`${platform}-${language}`}</span>
+      <ClassificationFilter
+        platforms={['ChatGPT', 'Claude']}
+        languages={['en', 'zh']}
+        selectedPlatform={platform}
+        selectedLanguage={language}
+        onPlatformChange={setPlatform}
+        onLanguageChange={setLanguage}
+      />
+    </>
+  )
+}
+
+describe('ClassificationFilter', () => {
+  test('changes platform and language selections', () => {
+    render(<Wrapper />)
+    fireEvent.change(screen.getByTestId('platform-filter'), { target: { value: 'ChatGPT' } })
+    fireEvent.change(screen.getByTestId('language-filter'), { target: { value: 'zh' } })
+    expect(screen.getByTestId('vals').textContent).toBe('ChatGPT-zh')
+  })
+})

--- a/src/pages/Explore.jsx
+++ b/src/pages/Explore.jsx
@@ -4,6 +4,7 @@ import UploadLinkBox from '../components/UploadLinkBox.jsx'
 import LinkCard from '../components/LinkCard.jsx'
 import PreviewCard from '../components/PreviewCard.jsx'
 import TagFilter from '../components/TagFilter.jsx'
+import ClassificationFilter from '../components/ClassificationFilter.jsx'
 import SummarizerAgent from '../agents/SummarizerAgent.js'
 
 // === 可見性旗標：公開視圖不顯示統計（之後要改可從環境變數或設定注入）===
@@ -55,11 +56,23 @@ function Explore() {
   const [selectedLink, setSelectedLink] = useState(null)
   const [userId, setUserId] = useState('')
   const [selectedTags, setSelectedTags] = useState([])
+  const [selectedPlatform, setSelectedPlatform] = useState('')
+  const [selectedLanguage, setSelectedLanguage] = useState('')
   const uploadRef = useRef(null)
 
   const availableTags = useMemo(
     () => Object.keys(tagCounts),
     [tagCounts]
+  )
+
+  const availablePlatforms = useMemo(
+    () => Array.from(new Set(links.map((l) => l.platform))),
+    [links]
+  )
+
+  const availableLanguages = useMemo(
+    () => Array.from(new Set(links.map((l) => l.language))),
+    [links]
   )
 
   const buildTagCounts = items => {
@@ -193,9 +206,14 @@ function Explore() {
   }
 
   const filteredLinks = useMemo(() => {
-    if (selectedTags.length === 0) return links
-    return links.filter(link => selectedTags.every(tag => link.tags.includes(tag)))
-  }, [links, selectedTags])
+    let result = links
+    if (selectedPlatform) result = result.filter(l => l.platform === selectedPlatform)
+    if (selectedLanguage) result = result.filter(l => l.language === selectedLanguage)
+    if (selectedTags.length > 0) {
+      result = result.filter(link => selectedTags.every(tag => link.tags.includes(tag)))
+    }
+    return result
+  }, [links, selectedPlatform, selectedLanguage, selectedTags])
 
   return (
     <div className="min-h-screen bg-gray-50 flex justify-center items-start px-6 py-8 overflow-x-hidden">
@@ -213,7 +231,15 @@ function Explore() {
           <div className="w-full md:w-7/12 space-y-6">
             <UploadLinkBox onAdd={handleAdd} ref={uploadRef} />
 
-            <div className="mt-2">
+            <div className="mt-2 space-y-2">
+              <ClassificationFilter
+                platforms={availablePlatforms}
+                languages={availableLanguages}
+                selectedPlatform={selectedPlatform}
+                selectedLanguage={selectedLanguage}
+                onPlatformChange={setSelectedPlatform}
+                onLanguageChange={setSelectedLanguage}
+              />
               <TagFilter
                 tags={availableTags}
                 selected={selectedTags}

--- a/src/pages/MyLinks.jsx
+++ b/src/pages/MyLinks.jsx
@@ -4,6 +4,7 @@ import UploadLinkBox from '../components/UploadLinkBox.jsx'
 import LinkCard from '../components/LinkCard.jsx'
 import PreviewCard from '../components/PreviewCard.jsx'
 import TagFilter from '../components/TagFilter.jsx'
+import ClassificationFilter from '../components/ClassificationFilter.jsx'
 import SummarizerAgent from '../agents/SummarizerAgent.js'
 import Sortable from 'sortablejs'
 
@@ -48,11 +49,23 @@ function MyLinks() {
   const [selectedLink, setSelectedLink] = useState(null)
   const [userId, setUserId] = useState('')
   const [selectedTags, setSelectedTags] = useState([])
+  const [selectedPlatform, setSelectedPlatform] = useState('')
+  const [selectedLanguage, setSelectedLanguage] = useState('')
   const [showStats, setShowStats] = useState(() => localStorage.getItem('showStats') !== '0')
   const listRef = useRef(null)
   const uploadRef = useRef(null)
 
   const availableTags = useMemo(() => Object.keys(tagCounts), [tagCounts])
+
+  const availablePlatforms = useMemo(
+    () => Array.from(new Set(links.map((l) => l.platform))),
+    [links]
+  )
+
+  const availableLanguages = useMemo(
+    () => Array.from(new Set(links.map((l) => l.language))),
+    [links]
+  )
 
   const buildTagCounts = (items) => {
     const counts = {}
@@ -218,9 +231,14 @@ function MyLinks() {
   }
 
   const filteredLinks = useMemo(() => {
-    if (selectedTags.length === 0) return links
-    return links.filter(link => selectedTags.every(tag => link.tags.includes(tag)))
-  }, [links, selectedTags])
+    let result = links
+    if (selectedPlatform) result = result.filter(l => l.platform === selectedPlatform)
+    if (selectedLanguage) result = result.filter(l => l.language === selectedLanguage)
+    if (selectedTags.length > 0) {
+      result = result.filter(link => selectedTags.every(tag => link.tags.includes(tag)))
+    }
+    return result
+  }, [links, selectedPlatform, selectedLanguage, selectedTags])
 
   return (
     <div className="min-h-screen bg-gray-50 flex justify-center items-start px-6 py-8 overflow-x-hidden">
@@ -249,7 +267,15 @@ function MyLinks() {
           <div className="w-full md:w-7/12 space-y-6">
             <UploadLinkBox onAdd={handleAdd} ref={uploadRef} />
 
-            <div className="mt-2">
+            <div className="mt-2 space-y-2">
+              <ClassificationFilter
+                platforms={availablePlatforms}
+                languages={availableLanguages}
+                selectedPlatform={selectedPlatform}
+                selectedLanguage={selectedLanguage}
+                onPlatformChange={setSelectedPlatform}
+                onLanguageChange={setSelectedLanguage}
+              />
               <TagFilter
                 tags={availableTags}
                 selected={selectedTags}


### PR DESCRIPTION
## Summary
- add `ClassificationFilter` component to filter links by platform and language
- integrate filters into Explore and MyLinks pages
- test classification filter component

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899ca463a988327b3c823e59b218761