### PR TITLE
refactor: remove clear button from classify filter

### DIFF
--- a/src/components/ClassifyFilter.jsx
+++ b/src/components/ClassifyFilter.jsx
@@ -20,33 +20,10 @@ function ClassifyFilter({
     onChange(next)
   }
 
-  const handleClear = (type) => {
-    if (!onChange) return
-    const next = {
-      tone: selectedTone,
-      theme: selectedTheme,
-      emotion: selectedEmotion,
-    }
-    next[type] = null
-    onChange(next)
-  }
-
   const renderGroup = (label, options, selectedValue, type) => (
     <div className="mb-4">
       <div className="flex items-center gap-2 mb-1">
         <span>{label}</span>
-        <button
-          type="button"
-          onClick={() => handleClear(type)}
-          className={`text-sm ${
-            selectedValue
-              ? 'text-blue-500 hover:underline'
-              : 'text-gray-300 cursor-not-allowed'
-          }`}
-          disabled={!selectedValue}
-        >
-          清除
-        </button>
       </div>
       <div className="flex flex-wrap gap-2 mt-1">
         {options.map((opt) => {

--- a/src/components/__tests__/ClassifyFilter.test.jsx
+++ b/src/components/__tests__/ClassifyFilter.test.jsx
@@ -1,0 +1,42 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import React from 'react'
+import ClassifyFilter from '../ClassifyFilter.jsx'
+
+function Wrapper() {
+  const [state, setState] = React.useState({
+    tone: null,
+    theme: null,
+    emotion: null,
+  })
+  return (
+    <>
+      <span data-testid="tone-val">{state.tone ?? ''}</span>
+      <ClassifyFilter
+        toneOptions={['正式']}
+        themeOptions={[]}
+        emotionOptions={[]}
+        selectedTone={state.tone}
+        selectedTheme={state.theme}
+        selectedEmotion={state.emotion}
+        onChange={setState}
+      />
+    </>
+  )
+}
+
+describe('ClassifyFilter', () => {
+  test('toggles selection by clicking the same option', () => {
+    render(<Wrapper />)
+    const option = screen.getByText('正式')
+    fireEvent.click(option)
+    expect(screen.getByTestId('tone-val').textContent).toBe('正式')
+    fireEvent.click(option)
+    expect(screen.getByTestId('tone-val').textContent).toBe('')
+  })
+
+  test('does not render clear button', () => {
+    render(<Wrapper />)
+    expect(screen.queryByText('清除')).toBeNull()
+  })
+})
+

--- a/src/components/__tests__/UploadLinkBox.test.jsx
+++ b/src/components/__tests__/UploadLinkBox.test.jsx
@@ -50,11 +50,11 @@ describe('UploadLinkBox tag suggestions', () => {
     // select tone/theme/emotion
     fireEvent.click(screen.getByText('理性'))
     fireEvent.click(screen.getByText('科技'))
-    fireEvent.click(screen.getByText('開心'))
+    fireEvent.click(screen.getByText('感動'))
 
     fireEvent.click(screen.getByText('新增'))
     expect(onAdd).toHaveBeenLastCalledWith(
-      expect.objectContaining({ classify: { tone: '理性', theme: '科技', emotion: '開心' } })
+      expect.objectContaining({ tone: '理性', theme: '科技', emotion: '感動' })
     )
 
     // second submission with tone cleared
@@ -67,7 +67,7 @@ describe('UploadLinkBox tag suggestions', () => {
     fireEvent.click(toneChip) // clear
     fireEvent.click(screen.getByText('新增'))
     expect(onAdd).toHaveBeenLastCalledWith(
-      expect.objectContaining({ classify: { tone: null, theme: null, emotion: null } })
+      expect.objectContaining({ tone: null, theme: null, emotion: null })
     )
   })
 })

--- a/src/pages/__tests__/MyLinks.test.jsx
+++ b/src/pages/__tests__/MyLinks.test.jsx
@@ -7,9 +7,9 @@ describe('MyLinks filtering', () => {
   test('filters by tone and tags with AND behaviour', () => {
     const user = 'user'
     const links = [
-      normalizeItem({ url: 'http://a', title: 'A', tags: ['t1'], classify: { tone: '理性' } }, user),
-      normalizeItem({ url: 'http://b', title: 'B', tags: ['t1'], classify: { tone: '感性' } }, user),
-      normalizeItem({ url: 'http://c', title: 'C', tags: ['t2'], classify: { tone: '理性' } }, user),
+      { ...normalizeItem({ url: 'http://a', title: 'A', tags: ['t1'] }, user), tone: '理性' },
+      { ...normalizeItem({ url: 'http://b', title: 'B', tags: ['t1'] }, user), tone: '感性' },
+      { ...normalizeItem({ url: 'http://c', title: 'C', tags: ['t2'] }, user), tone: '理性' },
     ]
 
     render(


### PR DESCRIPTION
## Summary
- simplify ClassifyFilter by removing Clear button and related logic
- add tests to ensure options toggle off on second click
- update UploadLinkBox and MyLinks tests for new classify API

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b10891c9883278f5d1ff50f980954