### PR TITLE
refactor: remove classify filtering

### DIFF
--- a/src/pages/Explore.jsx
+++ b/src/pages/Explore.jsx
@@ -4,7 +4,6 @@ import UploadLinkBox from '../components/UploadLinkBox.jsx'
 import LinkCard from '../components/LinkCard.jsx'
 import PreviewCard from '../components/PreviewCard.jsx'
 import TagFilter from '../components/TagFilter.jsx'
-import ClassifyFilter from '../components/ClassifyFilter.jsx'
 import SummarizerAgent from '../agents/SummarizerAgent.js'
 
 // === 可見性旗標：公開視圖不顯示統計（之後可由環境變數控制）===
@@ -60,22 +59,9 @@ function Explore() {
   const [selectedLink, setSelectedLink] = useState(null)
   const [userId, setUserId] = useState('')
   const [selectedTags, setSelectedTags] = useState([])
-  const [classify, setClassify] = useState({ tone: null, theme: null, emotion: null })
   const uploadRef = useRef(null)
 
   const availableTags = useMemo(() => Object.keys(tagCounts), [tagCounts])
-  const toneOptions = useMemo(
-    () => Array.from(new Set(links.map(l => l.tone).filter(Boolean))),
-    [links]
-  )
-  const themeOptions = useMemo(
-    () => Array.from(new Set(links.map(l => l.theme).filter(Boolean))),
-    [links]
-  )
-  const emotionOptions = useMemo(
-    () => Array.from(new Set(links.map(l => l.emotion).filter(Boolean))),
-    [links]
-  )
 
   const buildTagCounts = items => {
     const counts = {}
@@ -217,12 +203,9 @@ function Explore() {
       const tagMatch =
         selectedTags.length === 0 ||
         selectedTags.every(tag => link.tags.includes(tag))
-      const toneMatch = !classify.tone || link.tone === classify.tone
-      const themeMatch = !classify.theme || link.theme === classify.theme
-      const emotionMatch = !classify.emotion || link.emotion === classify.emotion
-      return tagMatch && toneMatch && themeMatch && emotionMatch
+      return tagMatch
     })
-  }, [links, selectedTags, classify])
+  }, [links, selectedTags])
 
   return (
     <div className="min-h-screen bg-gray-50 flex justify-center items-start px-6 py-8 overflow-x-hidden">
@@ -241,16 +224,6 @@ function Explore() {
             <UploadLinkBox onAdd={handleAdd} ref={uploadRef} />
 
             <div className="mt-2">
-              <ClassifyFilter
-                toneOptions={toneOptions}
-                themeOptions={themeOptions}
-                emotionOptions={emotionOptions}
-                selectedTone={classify.tone}
-                selectedTheme={classify.theme}
-                selectedEmotion={classify.emotion}
-                onChange={setClassify}
-              />
-
               <TagFilter
                 tags={availableTags}
                 selected={selectedTags}

--- a/src/pages/MyLinks.jsx
+++ b/src/pages/MyLinks.jsx
@@ -4,7 +4,6 @@ import UploadLinkBox from '../components/UploadLinkBox.jsx'
 import LinkCard from '../components/LinkCard.jsx'
 import PreviewCard from '../components/PreviewCard.jsx'
 import TagFilter from '../components/TagFilter.jsx'
-import ClassifyFilter from '../components/ClassifyFilter.jsx'
 import SummarizerAgent from '../agents/SummarizerAgent.js'
 import Sortable from 'sortablejs'
 import normalizeItem from '../utils/normalizeItem.js'
@@ -36,7 +35,6 @@ function buildTagCounts(items) {
 
 function MyLinks({
   initialLinks = null,
-  initialClassify = { tone: null, theme: null, emotion: null },
 }) {
   const summarizer = useMemo(() => new SummarizerAgent(), [])
   const [links, setLinks] = useState(initialLinks || [])
@@ -46,7 +44,6 @@ function MyLinks({
   const [selectedLink, setSelectedLink] = useState(null)
   const [userId, setUserId] = useState('')
   const [selectedTags, setSelectedTags] = useState([])
-  const [classify, setClassify] = useState(initialClassify)
   const [showStats, setShowStats] = useState(
     () => localStorage.getItem('showStats') !== '0'
   )
@@ -54,18 +51,6 @@ function MyLinks({
   const uploadRef = useRef(null)
 
   const availableTags = useMemo(() => Object.keys(tagCounts), [tagCounts])
-  const toneOptions = useMemo(
-    () => Array.from(new Set(links.map((l) => l.tone).filter(Boolean))),
-    [links]
-  )
-  const themeOptions = useMemo(
-    () => Array.from(new Set(links.map((l) => l.theme).filter(Boolean))),
-    [links]
-  )
-  const emotionOptions = useMemo(
-    () => Array.from(new Set(links.map((l) => l.emotion).filter(Boolean))),
-    [links]
-  )
 
   const increaseTagCounts = (tags) => {
     setTagCounts((prev) => {
@@ -233,12 +218,9 @@ function MyLinks({
       const tagMatch =
         selectedTags.length === 0 ||
         selectedTags.every((tag) => link.tags.includes(tag))
-      const toneMatch = !classify.tone || link.tone === classify.tone
-      const themeMatch = !classify.theme || link.theme === classify.theme
-      const emotionMatch = !classify.emotion || link.emotion === classify.emotion
-      return tagMatch && toneMatch && themeMatch && emotionMatch
+      return tagMatch
     })
-  }, [links, selectedTags, classify])
+  }, [links, selectedTags])
 
   return (
     <div className="min-h-screen bg-gray-50 flex justify-center items-start px-6 py-8 overflow-x-hidden">
@@ -267,16 +249,6 @@ function MyLinks({
             <UploadLinkBox onAdd={handleAdd} ref={uploadRef} />
 
             <div className="mt-2 space-y-3">
-              <ClassifyFilter
-                toneOptions={toneOptions}
-                themeOptions={themeOptions}
-                emotionOptions={emotionOptions}
-                selectedTone={classify.tone}
-                selectedTheme={classify.theme}
-                selectedEmotion={classify.emotion}
-                onChange={setClassify}
-              />
-
               <TagFilter
                 tags={availableTags}
                 selected={selectedTags}

--- a/src/pages/__tests__/MyLinks.test.jsx
+++ b/src/pages/__tests__/MyLinks.test.jsx
@@ -4,28 +4,29 @@ import MyLinks from '../MyLinks.jsx'
 import normalizeItem from '../../utils/normalizeItem.js'
 
 describe('MyLinks filtering', () => {
-  test('filters by tone and tags with AND behaviour', () => {
+  test('filters by tags with AND behaviour', () => {
     const user = 'user'
     const links = [
-      { ...normalizeItem({ url: 'http://a', title: 'A', tags: ['t1'] }, user), tone: '理性' },
-      { ...normalizeItem({ url: 'http://b', title: 'B', tags: ['t1'] }, user), tone: '感性' },
-      { ...normalizeItem({ url: 'http://c', title: 'C', tags: ['t2'] }, user), tone: '理性' },
+      { ...normalizeItem({ url: 'http://a', title: 'A', tags: ['t1'] }, user) },
+      { ...normalizeItem({ url: 'http://b', title: 'B', tags: ['t1'] }, user) },
+      { ...normalizeItem({ url: 'http://c', title: 'C', tags: ['t2'] }, user) },
     ]
 
     render(
       <MemoryRouter>
-        <MyLinks initialLinks={links} initialClassify={{ tone: '理性', theme: null, emotion: null }} />
+        <MyLinks initialLinks={links} />
       </MemoryRouter>
     )
 
-    // only tone "理性" links render
+    // all links render initially
     expect(screen.getByText('A')).toBeInTheDocument()
+    expect(screen.getByText('B')).toBeInTheDocument()
     expect(screen.getByText('C')).toBeInTheDocument()
-    expect(screen.queryByText('B')).toBeNull()
 
-    // apply tag filter t2 => AND filter
+    // apply tag filter t2
     fireEvent.click(screen.getAllByText('#t2')[0])
     expect(screen.queryByText('A')).toBeNull()
+    expect(screen.queryByText('B')).toBeNull()
     expect(screen.getByText('C')).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary
- drop ClassifyFilter and related state from Explore and MyLinks pages
- filter links by tags only
- update MyLinks tests for tag filtering

## Testing
- `npm run lint`
- `npm test`
- `npm run dev` (killed after startup)


------
https://chatgpt.com/codex/tasks/task_e_689b154d42108327a8ccd7c784e5ed4e