### PR TITLE
style: align home navigation buttons

### DIFF
--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { Link } from 'react-router-dom'
 import Header from '../components/Header.jsx'
 
 function Home() {
@@ -13,6 +14,14 @@ function Home() {
           <li>用標籤整理與再搜尋</li>
           <li>一鍵預覽與二次分享</li>
         </ul>
+        <div className="flex justify-center gap-4">
+          <Link to="/explore" className="px-4 py-2 bg-blue-500 text-white rounded">
+            探索
+          </Link>
+          <Link to="/my-links" className="px-4 py-2 bg-blue-500 text-white rounded">
+            我的連結
+          </Link>
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- center and evenly space Explore and My Links buttons on the home page

## Testing
- `npm run lint`
- `npm test`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_689b1552923083278c2f75ee09d9dec2